### PR TITLE
fix(settings): ALLOWED_HOSTS + CSRF_TRUSTED_ORIGINS via env

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -30,6 +30,10 @@ SECRET_KEY = os.getenv("SECRET_KEY", get_random_secret_key())
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "t", "1")
 
+# ALLOWED_HOSTS lido de env (default: localhost). Necessario quando DEBUG=False.
+ALLOWED_HOSTS = [h.strip() for h in os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",") if h.strip()]
+
+
 # Allowed origins on CORS
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
@@ -110,7 +114,10 @@ MIDDLEWARE = [
 ]
 
 CSRF_TRUSTED_ORIGINS = [
-    "https://*.2023-2-measuresoftgram-service-production.up.railway.app"
+    o.strip() for o in os.getenv(
+        "CSRF_TRUSTED_ORIGINS",
+        "https://*.2023-2-measuresoftgram-service-production.up.railway.app"
+    ).split(",") if o.strip()
 ]
 ROOT_URLCONF = "config.urls"
 


### PR DESCRIPTION
# fix(settings): ALLOWED_HOSTS + CSRF_TRUSTED_ORIGINS via env

## Descrição

Adiciona `ALLOWED_HOSTS` lendo de env var (default: `localhost,127.0.0.1`) e migra `CSRF_TRUSTED_ORIGINS` para também ler de env (mantém o default antigo do Railway como fallback). Diff: 8 linhas em `src/config/settings.py`.

Issue completa com reprodução: [#4](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Service/issues/4)

## Porque este Pull Request é necessário?

Sem essa correção, qualquer deploy fora do Railway/Heroku quebra:

- `ALLOWED_HOSTS` não estava definido no `settings.py`. Com `DEBUG=False`, o default do Django é `[]` e toda requisição responde **400 Bad Request: Invalid HTTP_HOST header**. Não dava pra resolver via env, exigia editar o arquivo.
- `CSRF_TRUSTED_ORIGINS` estava hardcoded com a URL antiga do Railway (`*.2023-2-measuresoftgram-service-production.up.railway.app`), sem fallback. Login/admin quebrava com erro de CSRF em qualquer domínio novo.

Identificado durante deploy de homologação em `msgram-api.synaptha.com` para teste do projeto da disciplina.

## Como verificar

Sem o patch:
```bash
DEBUG=False python manage.py runserver
curl -H "Host: meu-dominio.com" http://localhost:8000/
# → 400 Bad Request: Invalid HTTP_HOST header
```

Com o patch:
```bash
DEBUG=False ALLOWED_HOSTS="meu-dominio.com" python manage.py runserver
curl -H "Host: meu-dominio.com" http://localhost:8000/
# → 200 OK
```

## Critérios de aceitação

1. [x] Defaults preservam o comportamento atual (local + Railway antigo).
2. [x] Deploy próprio só precisa setar duas env vars (`ALLOWED_HOSTS` e `CSRF_TRUSTED_ORIGINS`).
3. [x] Diff mínimo — só 8 linhas, escopo cirúrgico.
4. [x] Sem mudança de dependência ou config externa.

Closes #4