### PR TITLE
fix(math_model): atomic calculate + in-memory pipeline (US12)

### DIFF
--- a/src/math_model/services.py
+++ b/src/math_model/services.py
@@ -1,258 +1,412 @@
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from django.db import transaction
+
 from characteristics.models import CalculatedCharacteristic, SupportedCharacteristic
+from characteristics.serializers import CalculatedCharacteristicSerializer
+from measures.models import CalculatedMeasure, SupportedMeasure
+from measures.serializers import CalculatedMeasureSerializer
+from metrics.models import CollectedMetric, SupportedMetric
+from metrics.serializers import CollectedMetricSerializer
 from resources import (
+    calculate_characteristics,
     calculate_measures,
     calculate_subcharacteristics,
-    calculate_characteristics,
-    calculate_tsqmi
+    calculate_tsqmi,
 )
-from measures.serializers import CalculatedMeasureSerializer
-from measures.models import CalculatedMeasure, SupportedMeasure
-from organizations.models import Repository
-from metrics.serializers import CollectedMetricSerializer
-from metrics.models import CollectedMetric, SupportedMetric
-from subcharacteristics.models import CalculatedSubCharacteristic, SupportedSubCharacteristic
+from subcharacteristics.models import (
+    CalculatedSubCharacteristic,
+    SupportedSubCharacteristic,
+)
+from subcharacteristics.serializers import CalculatedSubCharacteristicSerializer
 from tsqmi.models import TSQMI
 from tsqmi.serializers import TSQMISerializer
-from utils import utils, namefy
-from characteristics.serializers import CalculatedCharacteristicSerializer
-from subcharacteristics.serializers import CalculatedSubCharacteristicSerializer
 
 
-class MathModelServices():
-    # Logica de negocio de todo o modelo matematico
+# Métricas multi-valor (lista de floats por arquivo) — espelha
+# SupportedMetric.get_latest_metric_value em metrics/models.py:46.
+_LISTED_FIL_METRICS = frozenset({
+    'coverage',
+    'complexity',
+    'functions',
+    'comment_lines_density',
+    'duplicated_lines_density',
+})
+_UTS_METRICS = frozenset({'test_execution_time', 'tests'})
+_GITHUB_METRICS = frozenset({
+    'total_issues',
+    'resolved_issues',
+    'sum_ci_feedback_times',
+    'total_builds',
+})
+
+
+class MathModelServices:
+    """
+    Orquestra o cálculo do modelo matemático em duas fases:
+
+    1. build_*: constrói entidades em memória a partir do payload da
+       Action, sem tocar o banco. Permite que falhas matemáticas
+       aconteçam antes de qualquer escrita.
+    2. persist_all: dentro de transaction.atomic, persiste as 5 camadas
+       em sequência. Falha em qualquer passo dispara rollback completo.
+
+    A leitura de CollectedMetric do banco com janela de 20min
+    (metrics/models.py:113) sai do fluxo — métricas vêm exclusivamente
+    do payload, conforme Cenário 3 da US12.
+    """
+
     def __init__(self, repository, product):
         self.repository = repository
         self.product = product
 
-    def collect_metrics(self, data):
-        # Insercao de metricas do sonar e github
+    # ---------- FASE 1: build em memória ----------
+
+    def build_collected_metrics(self, data: dict) -> List[CollectedMetric]:
+        """Constrói instâncias não-persistidas de CollectedMetric a
+        partir do payload bruto da Action (SonarQube + GitHub)."""
         supported_metrics = {
-            supported_metric.key: supported_metric
-            for supported_metric in SupportedMetric.objects.all()
+            sm.key: sm for sm in SupportedMetric.objects.all()
         }
 
-        collected_metrics = []
-        if data.get("github"):
-            for metric in data["github"]["metrics"]:
-                metric_key = metric["name"]
-                metric_value = metric["value"]
-                collected_metrics.append(
+        collected: List[CollectedMetric] = []
+
+        if data.get('github'):
+            for metric in data['github']['metrics']:
+                key = metric['name']
+                if key not in supported_metrics:
+                    continue
+                collected.append(
                     CollectedMetric(
-                        metric=supported_metrics[metric_key],
-                        value=float(metric_value),
+                        metric=supported_metrics[key],
+                        value=float(metric['value']),
                         repository=self.repository,
-                        qualifier="TRK"
+                        qualifier='TRK',
                     )
                 )
-        if data.get("sonarqube"):
-            for component in data["sonarqube"]['components']:
-                for obj in component['measures']:
-                    metric_key = obj['metric']
-                    metric_value = obj['value']
 
-                    collected_metrics.append(
+        if data.get('sonarqube'):
+            for component in data['sonarqube']['components']:
+                for obj in component['measures']:
+                    key = obj['metric']
+                    if key not in supported_metrics:
+                        continue
+                    collected.append(
                         CollectedMetric(
                             qualifier=component['qualifier'],
                             path=component['path'],
-                            metric=supported_metrics[metric_key],
-                            value=float(metric_value),
-                            repository=self.repository
+                            metric=supported_metrics[key],
+                            value=float(obj['value']),
+                            repository=self.repository,
                         )
                     )
-        saved_metrics = CollectedMetric.objects.bulk_create(collected_metrics)
-        serializer_metrics = CollectedMetricSerializer(
-            saved_metrics,
-            many=True
-        )
 
-        return serializer_metrics.data
+        return collected
 
-    def calculate_measures(self, measure_keys, release_configuration):
-        # Calculo de medidas a partir de metricas inseridas
+    def build_calculated_measures(
+        self,
+        measure_keys: List[str],
+        release_configuration,
+        collected_metrics: List[CollectedMetric],
+    ) -> Tuple[List[CalculatedMeasure], Dict[str, float]]:
+        """Calcula medidas a partir das métricas em memória."""
+        metric_index = self._index_metrics_by_key(collected_metrics)
+
         qs = SupportedMeasure.objects.filter(
             key__in=measure_keys
-        ).prefetch_related(
-            'metrics',
-            'metrics__collected_metrics',
-        )
+        ).prefetch_related('metrics')
 
         core_params = {'measures': []}
-
-        measure: SupportedMeasure
         for measure in qs:
-            metric_params = measure.get_latest_metric_params(self.repository)
+            metric_params = self._resolve_metric_params_in_memory(
+                measure, metric_index,
+            )
             if metric_params:
-                core_params['measures'].append(
-                    {
-                        'key': measure.key,
-                        'metrics': [
-                            {
-                                "key": key,
-                                "value": [float(v) for v in value] if isinstance(value, list) else [float(value)]
-                            }
-                            for key, value in metric_params.items()
-                        ]
-                    }
-                )
-        calculate_result = calculate_measures(core_params, release_configuration.data)
+                core_params['measures'].append({
+                    'key': measure.key,
+                    'metrics': [
+                        {
+                            'key': key,
+                            'value': (
+                                [float(v) for v in value]
+                                if isinstance(value, list)
+                                else [float(value)]
+                            ),
+                        }
+                        for key, value in metric_params.items()
+                    ],
+                })
 
+        calculated_result = calculate_measures(
+            core_params, release_configuration.data,
+        )
         calculated_values = {
-            measure['key']: measure['value']
-            for measure in calculate_result['measures']
+            m['key']: m['value'] for m in calculated_result['measures']
         }
 
-        calculated_measures = []
-
-        measure: SupportedMeasure
+        instances: List[CalculatedMeasure] = []
         for measure in qs:
             if measure.key not in calculated_values:
                 continue
-
-            value = calculated_values[measure.key]
-
-            calculated_measures.append(
+            instances.append(
                 CalculatedMeasure(
                     measure=measure,
-                    value=value,
-                    repository=self.repository
+                    value=calculated_values[measure.key],
+                    repository=self.repository,
                 )
             )
-        saved_measures = CalculatedMeasure.objects.bulk_create(calculated_measures)
-        serializer_measures = CalculatedMeasureSerializer(
-            saved_measures,
-            many=True
-        )
-        return serializer_measures.data
 
-    def calculate_sucharacteristics(self, subcharacteristics_keys, release_configuration):
-        query_set = SupportedSubCharacteristic.objects.filter(
-            key__in=subcharacteristics_keys
-        ).prefetch_related(
-            'measures',
-            'measures__calculated_measures',
-        )
+        return instances, calculated_values
+
+    def build_calculated_subcharacteristics(
+        self,
+        subcharacteristic_keys: List[str],
+        release_configuration,
+        measure_values: Dict[str, float],
+    ) -> Tuple[List[CalculatedSubCharacteristic], Dict[str, float]]:
+        """Calcula subcaracterísticas a partir das medidas em memória."""
+        qs = SupportedSubCharacteristic.objects.filter(
+            key__in=subcharacteristic_keys
+        ).prefetch_related('measures')
 
         core_params = {'subcharacteristics': []}
-
-        for subchar in query_set:
-            subchar: SupportedSubCharacteristic
-            measure_params = subchar.get_latest_measure_params(release_configuration)
-            core_params['subcharacteristics'].append(
-                {
-                    'key': subchar.key,
-                    'measures': measure_params,
-                }
+        for subchar in qs:
+            measure_params = self._resolve_measure_params_in_memory(
+                subchar, release_configuration, measure_values,
             )
+            core_params['subcharacteristics'].append({
+                'key': subchar.key,
+                'measures': measure_params,
+            })
 
-        calculate_result = calculate_subcharacteristics(core_params)
-
+        calculated_result = calculate_subcharacteristics(core_params)
         calculated_values = {
-            subcharacteristic['key']: subcharacteristic['value']
-            for subcharacteristic in calculate_result['subcharacteristics']
+            s['key']: s['value']
+            for s in calculated_result['subcharacteristics']
         }
 
-        calculated_subcharacteristics = []
-
-        subchar: SupportedSubCharacteristic
-        for subchar in query_set:
-            value = calculated_values[subchar.key]
-
-            calculated_subcharacteristics.append(
+        instances: List[CalculatedSubCharacteristic] = []
+        for subchar in qs:
+            instances.append(
                 CalculatedSubCharacteristic(
                     subcharacteristic=subchar,
-                    value=value,
-                    repository=self.repository
+                    value=calculated_values[subchar.key],
+                    repository=self.repository,
                 )
             )
 
-        saved_subchar = CalculatedSubCharacteristic.objects.bulk_create(calculated_subcharacteristics)
-        serializer_subchar = CalculatedSubCharacteristicSerializer(
-            saved_subchar,
-            many=True
-        )
-        return serializer_subchar.data
+        return instances, calculated_values
 
-    def calculcate_characterisctics(self, characteristics_keys, release_configuration):
+    def build_calculated_characteristics(
+        self,
+        characteristic_keys: List[str],
+        release_configuration,
+        subcharacteristic_values: Dict[str, float],
+    ) -> Tuple[List[CalculatedCharacteristic], Dict[str, float]]:
+        """Calcula características a partir das subcaracterísticas
+        em memória."""
         qs = SupportedCharacteristic.objects.filter(
-            key__in=characteristics_keys
-        ).prefetch_related(
-            'subcharacteristics',
-            'subcharacteristics__calculated_subcharacteristics',
-        )
+            key__in=characteristic_keys
+        ).prefetch_related('subcharacteristics')
 
         core_params = {'characteristics': []}
-
-        char: SupportedCharacteristic
         for char in qs:
-            subchars_params = char.get_latest_subcharacteristics_params(
-                release_configuration,
+            subchars_params = self._resolve_subcharacteristic_params_in_memory(
+                char, release_configuration, subcharacteristic_values,
             )
+            core_params['characteristics'].append({
+                'key': char.key,
+                'subcharacteristics': subchars_params,
+            })
 
-            core_params['characteristics'].append(
-                {
-                    'key': char.key,
-                    'subcharacteristics': subchars_params,
-                }
-            )
-
-        calculate_result = calculate_characteristics(core_params)
-
+        calculated_result = calculate_characteristics(core_params)
         calculated_values = {
-            characteristic['key']: characteristic['value']
-            for characteristic in calculate_result['characteristics']
+            c['key']: c['value']
+            for c in calculated_result['characteristics']
         }
 
-        calculated_characteristics = []
-
-        for characteristic in qs:
-            value = calculated_values[characteristic.key]
-
-            calculated_characteristics.append(
+        instances: List[CalculatedCharacteristic] = []
+        for char in qs:
+            instances.append(
                 CalculatedCharacteristic(
-                    characteristic=characteristic,
-                    value=value,
-                    repository=self.repository
+                    characteristic=char,
+                    value=calculated_values[char.key],
+                    repository=self.repository,
                 )
             )
-        saved_char = CalculatedCharacteristic.objects.bulk_create(calculated_characteristics)
-        serializer_char = CalculatedCharacteristicSerializer(
-            saved_char,
-            many=True
-        )
-        return serializer_char.data
 
-    def calculate_tsqmi(self, release_configuration):
-        characteristics_keys = [
-            characteristic['key']
-            for characteristic in release_configuration.data['characteristics']
-        ]
-        qs = (
-            SupportedCharacteristic.objects.filter(
-                key__in=characteristics_keys
-            )
-            .prefetch_related('calculated_characteristics')
-            .first()
-        )
+        return instances, calculated_values
 
+    def build_tsqmi(
+        self,
+        release_configuration,
+        characteristic_values: Dict[str, float],
+    ) -> TSQMI:
+        """Calcula o TSQMI final a partir das características em memória.
+
+        Retorna instância não persistida.
+        """
         chars_params = []
-        chars_params = qs.get_latest_characteristics_params(
-            release_configuration,
-        )
+        for char_data in release_configuration.data['characteristics']:
+            key = char_data['key']
+            weight = release_configuration.get_characteristic_weight(key)
+            if weight:
+                chars_params.append({
+                    'key': key,
+                    'value': characteristic_values.get(key),
+                    'weight': weight,
+                })
 
         core_params = {
-            'tsqmi': {
-                'key': 'tsqmi',
-                'characteristics': chars_params,
-            }
+            'tsqmi': {'key': 'tsqmi', 'characteristics': chars_params},
+        }
+        calculated_result = calculate_tsqmi(core_params)
+        tsqmi_value = calculated_result.get('tsqmi')[0]['value']
+
+        return TSQMI(repository=self.repository, value=tsqmi_value)
+
+    # ---------- FASE 2: persistência atômica ----------
+
+    @transaction.atomic
+    def persist_all(
+        self,
+        collected_metrics: List[CollectedMetric],
+        calculated_measures: List[CalculatedMeasure],
+        calculated_subchars: List[CalculatedSubCharacteristic],
+        calculated_chars: List[CalculatedCharacteristic],
+        tsqmi: TSQMI,
+    ) -> dict:
+        """Persiste as 5 camadas em uma única transação atômica.
+
+        Falha em qualquer bulk_create dispara rollback completo via
+        propagação de exceção pra fora do @transaction.atomic.
+        """
+        saved_metrics = CollectedMetric.objects.bulk_create(collected_metrics)
+        saved_measures = CalculatedMeasure.objects.bulk_create(calculated_measures)
+        saved_subchars = CalculatedSubCharacteristic.objects.bulk_create(
+            calculated_subchars,
+        )
+        saved_chars = CalculatedCharacteristic.objects.bulk_create(
+            calculated_chars,
+        )
+        tsqmi.save()
+
+        return {
+            'metrics': CollectedMetricSerializer(saved_metrics, many=True).data,
+            'measures': CalculatedMeasureSerializer(saved_measures, many=True).data,
+            'subcharacteristics': CalculatedSubCharacteristicSerializer(
+                saved_subchars, many=True,
+            ).data,
+            'characteristics': CalculatedCharacteristicSerializer(
+                saved_chars, many=True,
+            ).data,
+            'tsqmi': TSQMISerializer(tsqmi).data,
         }
 
-        calculate_result = calculate_tsqmi(core_params)
+    # ---------- helpers in-memory ----------
 
-        data = calculate_result.get('tsqmi')[0]
+    @staticmethod
+    def _index_metrics_by_key(
+        collected_metrics: List[CollectedMetric],
+    ) -> Dict[str, List[CollectedMetric]]:
+        """Agrupa métricas por SupportedMetric.key."""
+        index: Dict[str, List[CollectedMetric]] = defaultdict(list)
+        for cm in collected_metrics:
+            index[cm.metric.key].append(cm)
+        return index
 
-        tsqmi = TSQMI.objects.create(
-            repository=self.repository,
-            value=data['value']
-        )
-        serializer = TSQMISerializer(tsqmi)
-        return serializer.data
+    @staticmethod
+    def _resolve_metric_params_in_memory(
+        measure: SupportedMeasure,
+        metric_index: Dict[str, List[CollectedMetric]],
+    ) -> Dict[str, object]:
+        """Substitui SupportedMeasure.get_latest_metric_params(repo)
+        lendo do índice em memória.
+
+        Replica a lógica de SupportedMetric.get_latest_metric_value
+        (metrics/models.py:46) sem janela de 20min e sem ir ao banco.
+
+        Resolve também o write/read TRK/FIL inconsistente (Service #9):
+        métricas GitHub são escritas com qualifier='TRK' em
+        build_collected_metrics e lidas aqui também filtrando 'TRK'
+        — coerente em ambas as pontas.
+        """
+        # arquivos com ncloc=0 são excluídos das métricas listed FIL,
+        # espelhando metrics/models.py:125-141.
+        empty_paths = {
+            cm.path for cm in metric_index.get('ncloc', [])
+            if cm.qualifier == 'FIL' and cm.value == 0
+        }
+
+        params: Dict[str, object] = {}
+        for supported_metric in measure.metrics.all():
+            key = supported_metric.key
+            cms = metric_index.get(key, [])
+
+            if key in _LISTED_FIL_METRICS:
+                # Lista de valores (1 por arquivo). Vazia se ausente —
+                # msgram-core mantém como lista (não desempacota com len!=1)
+                # e medidas como passed_tests retornam 0.0 nesse caso.
+                params[key] = [
+                    cm.value for cm in cms
+                    if cm.qualifier == 'FIL' and cm.path not in empty_paths
+                ]
+            elif key in _UTS_METRICS:
+                params[key] = [
+                    cm.value for cm in cms if cm.qualifier == 'UTS'
+                ]
+            elif key in _GITHUB_METRICS:
+                value = next(
+                    (cm.value for cm in cms if cm.qualifier == 'TRK'),
+                    None,
+                )
+                params[key] = value if value is not None else 0
+            else:
+                value = next(
+                    (cm.value for cm in cms if cm.qualifier == 'TRK'),
+                    None,
+                )
+                params[key] = value if value is not None else 0
+
+        return params
+
+    @staticmethod
+    def _resolve_measure_params_in_memory(
+        subchar: SupportedSubCharacteristic,
+        release_configuration,
+        measure_values: Dict[str, float],
+    ) -> List[dict]:
+        """Substitui SupportedSubCharacteristic.get_latest_measure_params
+        (subcharacteristics/models.py:50) lendo do dict em memória."""
+        params = []
+        for measure in subchar.measures.all():
+            weight = release_configuration.get_measure_weight(measure.key)
+            if weight:
+                params.append({
+                    'key': measure.key,
+                    'value': measure_values.get(measure.key),
+                    'weight': weight,
+                })
+        return params
+
+    @staticmethod
+    def _resolve_subcharacteristic_params_in_memory(
+        char: SupportedCharacteristic,
+        release_configuration,
+        subchar_values: Dict[str, float],
+    ) -> List[dict]:
+        """Substitui SupportedCharacteristic.get_latest_subcharacteristics_params
+        (characteristics/models.py:65) lendo do dict em memória."""
+        params = []
+        for subchar in char.subcharacteristics.all():
+            weight = release_configuration.get_subcharacteristic_weight(
+                subchar.key,
+            )
+            if weight:
+                params.append({
+                    'key': subchar.key,
+                    'value': subchar_values.get(subchar.key),
+                    'weight': weight,
+                })
+        return params

--- a/src/math_model/tests/test_atomicity_smoke.py
+++ b/src/math_model/tests/test_atomicity_smoke.py
@@ -1,0 +1,144 @@
+"""
+Smoke test do bug de atomicidade no endpoint de cálculo do modelo
+matemático.
+
+Cobre o Cenário 2 da US12 (Service refactor):
+> Quando ocorre um erro em qualquer etapa do cálculo das hierarquias
+> ou medidas, o sistema deve interromper a operação e nenhuma métrica
+> parcial deve ser inserida no banco.
+
+Hoje (sem @transaction.atomic em math_model/views.py:32-42), os
+bulk_create dos passos 1 e 2 já foram commitados quando o passo 3
+falha — banco fica em estado parcialmente calculado.
+
+Este teste mocka calculate_subcharacteristics (msgram-core) com
+side_effect=CalculateModelException no passo 3 e asserta que
+CalculatedMeasure deveria estar vazia. Vai FALHAR no código atual
+(red), provando o bug. Após o fix (transaction.atomic envolvendo
+o fluxo na view), vira green.
+"""
+from unittest.mock import patch
+
+from freezegun import freeze_time
+from rest_framework import status
+
+from utils.tests import APITestCaseExpanded
+from utils import staticfiles
+from utils.exceptions import CalculateModelException
+from release_configuration.models import ReleaseConfiguration
+from metrics.models import SupportedMetric, CollectedMetric
+from measures.models import CalculatedMeasure
+from subcharacteristics.models import CalculatedSubCharacteristic
+from characteristics.models import CalculatedCharacteristic
+from tsqmi.models import TSQMI
+
+
+@freeze_time("2024-09-08 20:00:00")
+class MathModelAtomicitySmokeTest(APITestCaseExpanded):
+    def setUp(self):
+        self.org = self.get_organization()
+        self.product = self.get_product(self.org)
+        self.repository = self.get_repository(self.product)
+        ReleaseConfiguration.objects.get_or_create(
+            name='Default pre-config',
+            data=staticfiles.DEFAULT_PRE_CONFIG,
+            product=self.product,
+        )
+        self.release_config = self.product.release_configuration.first()
+
+        # Pré-popula CollectedMetric pra que calculate_measures (passo 2)
+        # tenha dados pra ler. Mesmo conjunto usado em test_services.py.
+        listed_values = [
+            'coverage', 'complexity', 'functions',
+            'comment_lines_density', 'duplicated_lines_density',
+        ]
+        uts_values = ['test_execution_time', 'tests']
+        trk_values = ['test_failures', 'test_errors']
+        for values, qualifier in zip(
+            [listed_values, uts_values, trk_values],
+            ['FIL', 'UTS', 'TRK'],
+        ):
+            for metric in SupportedMetric.objects.filter(key__in=values):
+                CollectedMetric.objects.create(
+                    value=0.1, metric=metric, repository=self.repository,
+                    qualifier=qualifier,
+                )
+                CollectedMetric.objects.create(
+                    value=0.2, metric=metric, repository=self.repository,
+                    qualifier=qualifier,
+                )
+
+        github_values = [
+            'total_issues', 'resolved_issues',
+            'sum_ci_feedback_times', 'total_builds',
+        ]
+        for metric in SupportedMetric.objects.filter(key__in=github_values):
+            CollectedMetric.objects.create(
+                value=1, metric=metric, repository=self.repository,
+                qualifier='FIL',
+            )
+
+        self.initial_collected = CollectedMetric.objects.count()
+        assert self.initial_collected > 0, 'pré-condição quebrou'
+
+        self.url = (
+            f'/api/v1/organizations/{self.org.id}'
+            f'/products/{self.product.id}'
+            f'/repositories/{self.repository.id}'
+            f'/calculate/math-model/'
+        )
+
+    @patch(
+        'math_model.services.calculate_subcharacteristics',
+        side_effect=CalculateModelException(
+            'simulated mid-calculation failure (passo 3)'
+        ),
+    )
+    def test_falha_no_passo_3_deve_reverter_passos_anteriores(self, _mock):
+        """
+        Endpoint dispara fluxo de 5 passos. Mock força raise no passo 3
+        (calculate_subcharacteristics do msgram-core).
+
+        Estado esperado pós-falha (Cenário 2 da US):
+            - status 400
+            - CalculatedMeasure: 0 (passo 2 deveria ter sido revertido)
+            - CalculatedSubCharacteristic, Characteristic, TSQMI: 0
+            - CollectedMetric: == initial (não houve insert novo, payload vazio)
+
+        Hoje (sem @transaction.atomic na view): passo 2 commitou N
+        CalculatedMeasures antes do passo 3 raise — assert quebra (RED).
+        """
+        empty_payload = {
+            'github': {'metrics': []},
+            'sonarqube': {'components': []},
+        }
+
+        response = self.client.post(self.url, empty_payload, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+            f'esperava 400 (CalculateModelException), recebeu '
+            f'{response.status_code}: {response.content!r}'
+        )
+
+        assert CollectedMetric.objects.count() == self.initial_collected, (
+            f'CollectedMetric não deveria ter mudado; '
+            f'inicial={self.initial_collected}, '
+            f'atual={CollectedMetric.objects.count()}'
+        )
+
+        # AQUI MORA O BUG ATIVO: passo 2 (calculate_measures) commitou
+        # CalculatedMeasures antes do passo 3 (subcharacteristics) bater
+        # no mock e raise. Sem @transaction.atomic, esses inserts persistem.
+        leaked_measures = CalculatedMeasure.objects.count()
+        assert leaked_measures == 0, (
+            f'BUG DE ATOMICIDADE: passo 2 vazou {leaked_measures} '
+            f'CalculatedMeasure(s) apesar do passo 3 ter falhado. '
+            f'Falta @transaction.atomic envolvendo o fluxo em '
+            f'math_model/views.py:32-42.'
+        )
+
+        # Passos 3, 4, 5 nunca executaram — esses asserts são triviais
+        # (defensivos contra regressão de fluxo).
+        assert CalculatedSubCharacteristic.objects.count() == 0
+        assert CalculatedCharacteristic.objects.count() == 0
+        assert TSQMI.objects.count() == 0

--- a/src/math_model/tests/test_atomicity_smoke.py
+++ b/src/math_model/tests/test_atomicity_smoke.py
@@ -4,10 +4,18 @@ Smoke tests do endpoint de cálculo do modelo matemático.
 Cobertura dos cenários da US12:
 - Cenário 1 (fluxo feliz): payload válido → 201 + persistência completa.
 - Cenário 2 (falha mid-cálculo): mock força exceção → rollback total.
+- Cenário 3 (sem janela 20min): cálculo não lê CollectedMetric do banco
+  durante o POST — usa o payload em memória.
 
 Cenário 2 prova a "DOR DOCUMENTADA: ausência de transação" registrada
 em src/math_model/CLAUDE.md. Sem @transaction.atomic, falha em qualquer
 passo deixa rastros dos passos anteriores. Após o fix, vira green.
+
+Cenário 3 prova que o cálculo deixou de depender da janela de 20min em
+metrics/models.py:113. Hoje (mesmo com atomic), o fluxo chama
+SupportedMetric.get_latest_metric_value que ativa a janela. Após o
+refactor "calcula em memória", essa função não é mais consultada
+durante o POST.
 """
 from unittest.mock import patch
 
@@ -134,6 +142,62 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
         assert CalculatedSubCharacteristic.objects.count() == 0
         assert CalculatedCharacteristic.objects.count() == 0
         assert TSQMI.objects.count() == 0
+
+    def test_fluxo_post_nao_le_collected_metric_do_banco(self):
+        """
+        Cenário 3 da US12 — eliminar janela de 20min.
+
+        Hoje, calculate_measures chama
+        SupportedMeasure.get_latest_metric_params(repository)
+        em measures/models.py:39, que itera sobre as métricas e chama
+        SupportedMetric.get_latest_metric_value(repository) em
+        metrics/models.py:46 — função que ativa a janela de 20min em
+        metrics/models.py:113 para qualifiers FIL/UTS, e lê CollectedMetric
+        single-row para o resto.
+
+        Após o refactor "calcula em memória → persiste no fim", o cálculo
+        usa o payload da Action diretamente. get_latest_metric_value não
+        é mais consultada durante o POST. Essa função continua existindo
+        para outros usos (latest-values endpoint, etc), mas sai do fluxo
+        do cálculo.
+
+        Spy: substitui o método por um wrapper que conta chamadas.
+        """
+        from metrics.models import SupportedMetric
+
+        call_log = []
+        original = SupportedMetric.get_latest_metric_value
+
+        def spy(self_metric, repository):
+            call_log.append(self_metric.key)
+            return original(self_metric, repository)
+
+        empty_payload = {
+            'github': {'metrics': []},
+            'sonarqube': {'components': []},
+        }
+
+        with patch.object(
+            SupportedMetric, 'get_latest_metric_value', new=spy,
+        ):
+            response = self.client.post(
+                self.url, empty_payload, format='json',
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'esperava 201, recebeu {response.status_code}: '
+            f'{response.content!r}'
+        )
+
+        assert call_log == [], (
+            f'BUG: fluxo do POST consultou CollectedMetric do banco '
+            f'{len(call_log)} vez(es) via get_latest_metric_value: '
+            f'{call_log}. Cenário 3 da US12 exige cálculo em memória '
+            f'a partir do payload da Action — janela de 20min em '
+            f'metrics/models.py:113 deve sair desse fluxo. Refactor '
+            f'pendente: MathModelServices.calculate_measures deve '
+            f'receber métricas em memória, não buscar no banco.'
+        )
 
     def test_fluxo_feliz_persiste_todas_as_camadas(self):
         """

--- a/src/math_model/tests/test_atomicity_smoke.py
+++ b/src/math_model/tests/test_atomicity_smoke.py
@@ -9,13 +9,11 @@ Cobertura dos cenários da US12:
 
 Cenário 2 prova a "DOR DOCUMENTADA: ausência de transação" registrada
 em src/math_model/CLAUDE.md. Sem @transaction.atomic, falha em qualquer
-passo deixa rastros dos passos anteriores. Após o fix, vira green.
+passo deixa rastros dos passos anteriores.
 
 Cenário 3 prova que o cálculo deixou de depender da janela de 20min em
-metrics/models.py:113. Hoje (mesmo com atomic), o fluxo chama
-SupportedMetric.get_latest_metric_value que ativa a janela. Após o
-refactor "calcula em memória", essa função não é mais consultada
-durante o POST.
+metrics/models.py:113. Após o refactor "calcula em memória", a função
+SupportedMetric.get_latest_metric_value não é consultada durante o POST.
 """
 from unittest.mock import patch
 
@@ -33,6 +31,81 @@ from characteristics.models import CalculatedCharacteristic
 from tsqmi.models import TSQMI
 
 
+def _full_payload():
+    """Payload realista que cobre todas as 14 métricas alimentando as
+    8 medidas do DEFAULT_PRE_CONFIG.
+
+    Espelha o que a Action manda em produção (SonarQube components +
+    GitHub metrics)."""
+    return {
+        'github': {
+            'metrics': [
+                {'name': 'total_issues', 'value': 10},
+                {'name': 'resolved_issues', 'value': 8},
+                {'name': 'sum_ci_feedback_times', 'value': 300},
+                {'name': 'total_builds', 'value': 5},
+            ],
+        },
+        'sonarqube': {
+            'components': [
+                {
+                    'qualifier': 'FIL',
+                    'path': 'src/foo.py',
+                    'measures': [
+                        {'metric': 'coverage', 'value': 80.0},
+                        {'metric': 'complexity', 'value': 5},
+                        {'metric': 'functions', 'value': 10},
+                        {'metric': 'comment_lines_density', 'value': 20.0},
+                        {'metric': 'duplicated_lines_density', 'value': 0.0},
+                        {'metric': 'ncloc', 'value': 100},
+                    ],
+                },
+                {
+                    'qualifier': 'FIL',
+                    'path': 'src/bar.py',
+                    'measures': [
+                        {'metric': 'coverage', 'value': 60.0},
+                        {'metric': 'complexity', 'value': 8},
+                        {'metric': 'functions', 'value': 15},
+                        {'metric': 'comment_lines_density', 'value': 15.0},
+                        {'metric': 'duplicated_lines_density', 'value': 5.0},
+                        {'metric': 'ncloc', 'value': 200},
+                    ],
+                },
+                {
+                    'qualifier': 'UTS',
+                    'path': 'tests/foo_test.py',
+                    'measures': [
+                        {'metric': 'tests', 'value': 5},
+                        {'metric': 'test_execution_time', 'value': 100},
+                    ],
+                },
+                # Segundo arquivo UTS necessário pra que tests/test_execution_time
+                # cheguem ao msgram-core como lista (>1 valor). O helper
+                # convert_metrics_to_dict em resources/analysis.py desempacota
+                # listas de 1 elemento para float, o que quebra medidas que
+                # exigem lista (ex: passed_tests).
+                {
+                    'qualifier': 'UTS',
+                    'path': 'tests/bar_test.py',
+                    'measures': [
+                        {'metric': 'tests', 'value': 3},
+                        {'metric': 'test_execution_time', 'value': 80},
+                    ],
+                },
+                {
+                    'qualifier': 'TRK',
+                    'path': '',
+                    'measures': [
+                        {'metric': 'test_failures', 'value': 0},
+                        {'metric': 'test_errors', 'value': 0},
+                    ],
+                },
+            ],
+        },
+    }
+
+
 @freeze_time("2024-09-08 20:00:00")
 class MathModelAtomicitySmokeTest(APITestCaseExpanded):
     def setUp(self):
@@ -46,40 +119,15 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
         )
         self.release_config = self.product.release_configuration.first()
 
-        # Pré-popula CollectedMetric pra que calculate_measures (passo 2)
-        # tenha dados pra ler. Mesmo conjunto usado em test_services.py.
-        listed_values = [
-            'coverage', 'complexity', 'functions',
-            'comment_lines_density', 'duplicated_lines_density',
-        ]
-        uts_values = ['test_execution_time', 'tests']
-        trk_values = ['test_failures', 'test_errors']
-        for values, qualifier in zip(
-            [listed_values, uts_values, trk_values],
-            ['FIL', 'UTS', 'TRK'],
-        ):
-            for metric in SupportedMetric.objects.filter(key__in=values):
-                CollectedMetric.objects.create(
-                    value=0.1, metric=metric, repository=self.repository,
-                    qualifier=qualifier,
-                )
-                CollectedMetric.objects.create(
-                    value=0.2, metric=metric, repository=self.repository,
-                    qualifier=qualifier,
-                )
-
-        github_values = [
-            'total_issues', 'resolved_issues',
-            'sum_ci_feedback_times', 'total_builds',
-        ]
-        for metric in SupportedMetric.objects.filter(key__in=github_values):
-            CollectedMetric.objects.create(
-                value=1, metric=metric, repository=self.repository,
-                qualifier='FIL',
-            )
-
+        # Pré-popula uma métrica sentinela para distinguir, no cenário 3,
+        # o que veio do banco (não deveria ser usado) do que veio do
+        # payload (única fonte permitida pós-refactor).
+        ncloc = SupportedMetric.objects.get(key='ncloc')
+        CollectedMetric.objects.create(
+            value=999, metric=ncloc, repository=self.repository,
+            qualifier='FIL', path='legacy/old.py',
+        )
         self.initial_collected = CollectedMetric.objects.count()
-        assert self.initial_collected > 0, 'pré-condição quebrou'
 
         self.url = (
             f'/api/v1/organizations/{self.org.id}'
@@ -96,24 +144,19 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
     )
     def test_falha_no_passo_3_deve_reverter_passos_anteriores(self, _mock):
         """
-        Endpoint dispara fluxo de 5 passos. Mock força raise no passo 3
+        Cenário 2 da US12: mock força raise no passo 3
         (calculate_subcharacteristics do msgram-core).
 
-        Estado esperado pós-falha (Cenário 2 da US):
+        Estado esperado pós-falha:
             - status 400
-            - CalculatedMeasure: 0 (passo 2 deveria ter sido revertido)
-            - CalculatedSubCharacteristic, Characteristic, TSQMI: 0
-            - CollectedMetric: == initial (não houve insert novo, payload vazio)
+            - CollectedMetric: == initial (nada do payload persistiu)
+            - CalculatedMeasure, SubCharacteristic, Characteristic, TSQMI: 0
 
-        Hoje (sem @transaction.atomic na view): passo 2 commitou N
-        CalculatedMeasures antes do passo 3 raise — assert quebra (RED).
+        Sem rollback (estado pré-fix em math_model/views.py), o passo 2
+        commita CalculatedMeasures antes do passo 3 falhar — assert
+        de CalculatedMeasure.count() == 0 quebra (RED).
         """
-        empty_payload = {
-            'github': {'metrics': []},
-            'sonarqube': {'components': []},
-        }
-
-        response = self.client.post(self.url, empty_payload, format='json')
+        response = self.client.post(self.url, _full_payload(), format='json')
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST, (
             f'esperava 400 (CalculateModelException), recebeu '
@@ -121,24 +164,16 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
         )
 
         assert CollectedMetric.objects.count() == self.initial_collected, (
-            f'CollectedMetric não deveria ter mudado; '
-            f'inicial={self.initial_collected}, '
+            f'CollectedMetric vazou: inicial={self.initial_collected}, '
             f'atual={CollectedMetric.objects.count()}'
         )
 
-        # AQUI MORA O BUG ATIVO: passo 2 (calculate_measures) commitou
-        # CalculatedMeasures antes do passo 3 (subcharacteristics) bater
-        # no mock e raise. Sem @transaction.atomic, esses inserts persistem.
         leaked_measures = CalculatedMeasure.objects.count()
         assert leaked_measures == 0, (
             f'BUG DE ATOMICIDADE: passo 2 vazou {leaked_measures} '
-            f'CalculatedMeasure(s) apesar do passo 3 ter falhado. '
-            f'Falta @transaction.atomic envolvendo o fluxo em '
-            f'math_model/views.py:32-42.'
+            f'CalculatedMeasure(s) apesar do passo 3 ter falhado.'
         )
 
-        # Passos 3, 4, 5 nunca executaram — esses asserts são triviais
-        # (defensivos contra regressão de fluxo).
         assert CalculatedSubCharacteristic.objects.count() == 0
         assert CalculatedCharacteristic.objects.count() == 0
         assert TSQMI.objects.count() == 0
@@ -147,24 +182,11 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
         """
         Cenário 3 da US12 — eliminar janela de 20min.
 
-        Hoje, calculate_measures chama
-        SupportedMeasure.get_latest_metric_params(repository)
-        em measures/models.py:39, que itera sobre as métricas e chama
-        SupportedMetric.get_latest_metric_value(repository) em
-        metrics/models.py:46 — função que ativa a janela de 20min em
-        metrics/models.py:113 para qualifiers FIL/UTS, e lê CollectedMetric
-        single-row para o resto.
-
-        Após o refactor "calcula em memória → persiste no fim", o cálculo
-        usa o payload da Action diretamente. get_latest_metric_value não
-        é mais consultada durante o POST. Essa função continua existindo
-        para outros usos (latest-values endpoint, etc), mas sai do fluxo
-        do cálculo.
-
-        Spy: substitui o método por um wrapper que conta chamadas.
+        Spy em SupportedMetric.get_latest_metric_value (que ativa a
+        janela em metrics/models.py:113). Após o refactor "calcula
+        em memória", essa função não é consultada durante o POST —
+        métricas vêm exclusivamente do payload da Action.
         """
-        from metrics.models import SupportedMetric
-
         call_log = []
         original = SupportedMetric.get_latest_metric_value
 
@@ -172,16 +194,11 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
             call_log.append(self_metric.key)
             return original(self_metric, repository)
 
-        empty_payload = {
-            'github': {'metrics': []},
-            'sonarqube': {'components': []},
-        }
-
         with patch.object(
             SupportedMetric, 'get_latest_metric_value', new=spy,
         ):
             response = self.client.post(
-                self.url, empty_payload, format='json',
+                self.url, _full_payload(), format='json',
             )
 
         assert response.status_code == status.HTTP_201_CREATED, (
@@ -194,44 +211,34 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
             f'{len(call_log)} vez(es) via get_latest_metric_value: '
             f'{call_log}. Cenário 3 da US12 exige cálculo em memória '
             f'a partir do payload da Action — janela de 20min em '
-            f'metrics/models.py:113 deve sair desse fluxo. Refactor '
-            f'pendente: MathModelServices.calculate_measures deve '
-            f'receber métricas em memória, não buscar no banco.'
+            f'metrics/models.py:113 deve sair desse fluxo.'
         )
 
     def test_fluxo_feliz_persiste_todas_as_camadas(self):
         """
-        Cenário 1 da US: payload válido executa os 5 passos sem mock,
-        retorna 201 e persiste todas as camadas.
-
-        Serve de rede de proteção pro refactor "calcula em memória →
-        persiste no fim": shape da resposta e contagens não-zero
-        devem ser preservadas, mesmo que a implementação interna mude
-        (banco vs payload, intercalado vs no fim).
+        Cenário 1 da US12: payload válido executa os 5 passos sem mock,
+        retorna 201 e persiste todas as camadas em uma transação.
 
         Não compara valores — só shape — pra ficar robusto a mudanças
-        de leitura (banco com janela 20min vs payload em memória) que
-        podem alterar entradas do msgram-core.
+        de implementação interna.
         """
-        empty_payload = {
-            'github': {'metrics': []},
-            'sonarqube': {'components': []},
-        }
-
-        response = self.client.post(self.url, empty_payload, format='json')
+        response = self.client.post(self.url, _full_payload(), format='json')
 
         assert response.status_code == status.HTTP_201_CREATED, (
             f'esperava 201, recebeu {response.status_code}: '
             f'{response.content!r}'
         )
 
-        # Resposta tem as 5 chaves esperadas
         body = response.json()
         for key in ('metrics', 'measures', 'subcharacteristics',
                     'characteristics', 'tsqmi'):
             assert key in body, f'chave "{key}" ausente na resposta'
 
-        # As 4 camadas calculadas devem ter sido persistidas
+        # Métricas do payload devem estar persistidas (além das pré-existentes).
+        assert CollectedMetric.objects.count() > self.initial_collected, (
+            'métricas do payload não foram persistidas'
+        )
+
         assert CalculatedMeasure.objects.count() > 0, 'medidas não persistiram'
         assert CalculatedSubCharacteristic.objects.count() > 0, (
             'subcharacteristics não persistiram'

--- a/src/math_model/tests/test_atomicity_smoke.py
+++ b/src/math_model/tests/test_atomicity_smoke.py
@@ -1,21 +1,13 @@
 """
-Smoke test do bug de atomicidade no endpoint de cálculo do modelo
-matemático.
+Smoke tests do endpoint de cálculo do modelo matemático.
 
-Cobre o Cenário 2 da US12 (Service refactor):
-> Quando ocorre um erro em qualquer etapa do cálculo das hierarquias
-> ou medidas, o sistema deve interromper a operação e nenhuma métrica
-> parcial deve ser inserida no banco.
+Cobertura dos cenários da US12:
+- Cenário 1 (fluxo feliz): payload válido → 201 + persistência completa.
+- Cenário 2 (falha mid-cálculo): mock força exceção → rollback total.
 
-Hoje (sem @transaction.atomic em math_model/views.py:32-42), os
-bulk_create dos passos 1 e 2 já foram commitados quando o passo 3
-falha — banco fica em estado parcialmente calculado.
-
-Este teste mocka calculate_subcharacteristics (msgram-core) com
-side_effect=CalculateModelException no passo 3 e asserta que
-CalculatedMeasure deveria estar vazia. Vai FALHAR no código atual
-(red), provando o bug. Após o fix (transaction.atomic envolvendo
-o fluxo na view), vira green.
+Cenário 2 prova a "DOR DOCUMENTADA: ausência de transação" registrada
+em src/math_model/CLAUDE.md. Sem @transaction.atomic, falha em qualquer
+passo deixa rastros dos passos anteriores. Após o fix, vira green.
 """
 from unittest.mock import patch
 
@@ -142,3 +134,45 @@ class MathModelAtomicitySmokeTest(APITestCaseExpanded):
         assert CalculatedSubCharacteristic.objects.count() == 0
         assert CalculatedCharacteristic.objects.count() == 0
         assert TSQMI.objects.count() == 0
+
+    def test_fluxo_feliz_persiste_todas_as_camadas(self):
+        """
+        Cenário 1 da US: payload válido executa os 5 passos sem mock,
+        retorna 201 e persiste todas as camadas.
+
+        Serve de rede de proteção pro refactor "calcula em memória →
+        persiste no fim": shape da resposta e contagens não-zero
+        devem ser preservadas, mesmo que a implementação interna mude
+        (banco vs payload, intercalado vs no fim).
+
+        Não compara valores — só shape — pra ficar robusto a mudanças
+        de leitura (banco com janela 20min vs payload em memória) que
+        podem alterar entradas do msgram-core.
+        """
+        empty_payload = {
+            'github': {'metrics': []},
+            'sonarqube': {'components': []},
+        }
+
+        response = self.client.post(self.url, empty_payload, format='json')
+
+        assert response.status_code == status.HTTP_201_CREATED, (
+            f'esperava 201, recebeu {response.status_code}: '
+            f'{response.content!r}'
+        )
+
+        # Resposta tem as 5 chaves esperadas
+        body = response.json()
+        for key in ('metrics', 'measures', 'subcharacteristics',
+                    'characteristics', 'tsqmi'):
+            assert key in body, f'chave "{key}" ausente na resposta'
+
+        # As 4 camadas calculadas devem ter sido persistidas
+        assert CalculatedMeasure.objects.count() > 0, 'medidas não persistiram'
+        assert CalculatedSubCharacteristic.objects.count() > 0, (
+            'subcharacteristics não persistiram'
+        )
+        assert CalculatedCharacteristic.objects.count() > 0, (
+            'characteristics não persistiram'
+        )
+        assert TSQMI.objects.count() == 1, 'TSQMI não persistiu (esperava 1)'

--- a/src/math_model/tests/test_services.py
+++ b/src/math_model/tests/test_services.py
@@ -1,15 +1,32 @@
-from math_model.services import MathModelServices
+"""
+Testes unitários do MathModelServices.
+
+Após o refactor "calcula em memória → persiste no fim", o service
+expõe métodos build_* que recebem dados de camadas anteriores em
+memória (não buscam no banco) e retornam instâncias não persistidas.
+A persistência mora em persist_all dentro de transaction.atomic.
+
+Testes de integração end-to-end do endpoint vivem em
+test_atomicity_smoke.py.
+"""
+from freezegun import freeze_time
+
 from utils.tests import APITestCaseExpanded
 from utils import staticfiles
 from release_configuration.models import ReleaseConfiguration
-from release_configuration.serializers import ReleaseConfigurationSerializer
 from metrics.models import SupportedMetric, CollectedMetric
-from freezegun import freeze_time
-from measures.models import SupportedMeasure, CalculatedMeasure
-from subcharacteristics.models import SupportedSubCharacteristic, CalculatedSubCharacteristic
-from characteristics.models import CalculatedCharacteristic, SupportedCharacteristic
+from measures.models import CalculatedMeasure, SupportedMeasure
+from subcharacteristics.models import (
+    CalculatedSubCharacteristic,
+    SupportedSubCharacteristic,
+)
+from characteristics.models import (
+    CalculatedCharacteristic,
+    SupportedCharacteristic,
+)
+from tsqmi.models import TSQMI
+from math_model.services import MathModelServices
 from math_model import utils
-import dicts
 
 
 @freeze_time("2024-09-08 20:00:00")
@@ -26,115 +43,165 @@ class MathModelServicesTest(APITestCaseExpanded):
         self.release_config = self.product.release_configuration.first()
         self.services = MathModelServices(self.repository, self.product)
 
+    def _build_collected_metrics_for_all_measures(self):
+        """Cria CollectedMetric (não persistidos) cobrindo as 14 métricas
+        que alimentam as 8 medidas do DEFAULT_PRE_CONFIG."""
+        metrics = []
+        listed_fil = [
+            'coverage', 'complexity', 'functions',
+            'comment_lines_density', 'duplicated_lines_density',
+        ]
+        uts = ['test_execution_time', 'tests']
+        trk = ['test_failures', 'test_errors']
+        github = [
+            'total_issues', 'resolved_issues',
+            'sum_ci_feedback_times', 'total_builds',
+        ]
+
+        for keys, qualifier in [(listed_fil, 'FIL'), (uts, 'UTS'), (trk, 'TRK')]:
+            for sm in SupportedMetric.objects.filter(key__in=keys):
+                # 2 valores cada — necessário pra que listas cheguem
+                # ao msgram-core como list (não desempacotadas).
+                metrics.append(CollectedMetric(
+                    value=0.1, metric=sm, repository=self.repository,
+                    qualifier=qualifier,
+                ))
+                metrics.append(CollectedMetric(
+                    value=0.2, metric=sm, repository=self.repository,
+                    qualifier=qualifier,
+                ))
+
+        for sm in SupportedMetric.objects.filter(key__in=github):
+            metrics.append(CollectedMetric(
+                value=1, metric=sm, repository=self.repository,
+                qualifier='TRK',
+            ))
+
+        return metrics
+
     def test_if_parse_release_config(self):
+        from release_configuration.serializers import ReleaseConfigurationSerializer
         config_serializer = ReleaseConfigurationSerializer(self.release_config)
-        char_keys, subchar_keys, measure_keys = utils.parse_release_configuration(config_serializer.data)
-        assert char_keys == ['reliability', 'maintainability', 'functional_suitability']
-        assert subchar_keys == ['testing_status', 'maturity', 'modifiability', 'functional_completeness']
+        char_keys, subchar_keys, measure_keys = utils.parse_release_configuration(
+            config_serializer.data,
+        )
+        assert char_keys == [
+            'reliability', 'maintainability', 'functional_suitability',
+        ]
+        assert subchar_keys == [
+            'testing_status', 'maturity', 'modifiability',
+            'functional_completeness',
+        ]
         assert measure_keys == [
-            'passed_tests',
-            'test_builds',
-            'test_coverage',
-            'ci_feedback_time',
-            'non_complex_file_density',
-            'commented_file_density',
-            'duplication_absense',
-            'team_throughput'
+            'passed_tests', 'test_builds', 'test_coverage',
+            'ci_feedback_time', 'non_complex_file_density',
+            'commented_file_density', 'duplication_absense', 'team_throughput',
         ]
 
-    def test_if_calculate_measures_is_working(self):
-        listed_values = [
-            'coverage',
-            'complexity',
-            'functions',
-            'comment_lines_density',
-            'duplicated_lines_density',
-        ]
+    def test_build_calculated_measures_returns_instances_and_values(self):
+        """build_calculated_measures retorna instâncias não persistidas
+        + dict {key: value} para alimentar a próxima camada."""
+        collected = self._build_collected_metrics_for_all_measures()
+        measure_keys = [m.key for m in SupportedMeasure.objects.all()]
 
-        uts_values = ['test_execution_time', 'tests']
-        trk_values = ['test_failures', 'test_errors']
-
-        for values, qualifier in zip(
-            [listed_values, uts_values, trk_values], ['FIL', 'UTS', 'TRK']
-        ):
-            for metric in SupportedMetric.objects.filter(key__in=values):
-                CollectedMetric.objects.create(
-                    value=0.1,
-                    metric=metric,
-                    repository=self.repository,
-                    qualifier=qualifier,
-                )
-                CollectedMetric.objects.create(
-                    value=0.2,
-                    metric=metric,
-                    repository=self.repository,
-                    qualifier=qualifier,
-                )
-
-        listed_values = [
-            'total_issues',
-            'resolved_issues',
-            'sum_ci_feedback_times',
-            'total_builds',
-        ]
-        for values, qualifier in zip(
-            [listed_values], ['FIL']
-        ):
-            for metric in SupportedMetric.objects.filter(key__in=values):
-                CollectedMetric.objects.create(
-                    value=1,
-                    metric=metric,
-                    repository=self.repository,
-                    qualifier=qualifier,
-                )
-        measures_keys = [
-
-            measure.key for measure in SupportedMeasure.objects.all()
-        ]
-        calculated_measures = self.services.calculate_measures(
-            measure_keys=measures_keys,
-            release_configuration=self.release_config
+        instances, values = self.services.build_calculated_measures(
+            measure_keys, self.release_config, collected,
         )
-        assert calculated_measures == dicts.MEASURE_RESPONSE
 
-    def test_if_calculate_subcharacteristics_is_working(self):
+        # Não persistiu nada
+        assert CalculatedMeasure.objects.count() == 0
+        # Todas as 8 medidas foram calculadas
+        assert len(instances) == 8
+        assert all(isinstance(i, CalculatedMeasure) for i in instances)
+        assert all(i.pk is None for i in instances)
+        # Dict tem as mesmas keys, valores são floats
+        assert set(values.keys()) == set(measure_keys)
+        assert all(isinstance(v, float) for v in values.values())
 
-        qs = self.release_config.get_subcharacteristics_qs()
+    def test_build_calculated_subcharacteristics_uses_in_memory_values(self):
+        measure_values = {
+            m.key: 0.1 for m in SupportedMeasure.objects.all()
+        }
+        subchar_keys = [
+            s.key for s in self.release_config.get_subcharacteristics_qs()
+        ]
 
-        for measure in SupportedMeasure.objects.all():
-            CalculatedMeasure.objects.create(
-                value=0.1, measure=measure, repository=self.repository
-            )
-
-        keys = [subcharacteristic.key for subcharacteristic in qs]
-        subchar = self.services.calculate_sucharacteristics(
-            subcharacteristics_keys=keys,
-            release_configuration=self.release_config
+        instances, values = self.services.build_calculated_subcharacteristics(
+            subchar_keys, self.release_config, measure_values,
         )
-        assert subchar == dicts.SUBCHAR_RESPONSE
 
-    def test_if_calculate_characteristics_is_working(self):
-        qs = self.release_config.get_characteristics_qs()
+        assert CalculatedSubCharacteristic.objects.count() == 0
+        assert len(instances) == len(subchar_keys)
+        assert all(isinstance(i, CalculatedSubCharacteristic) for i in instances)
+        assert all(i.pk is None for i in instances)
+        assert set(values.keys()) == set(subchar_keys)
 
-        for sub_char in SupportedSubCharacteristic.objects.all():
-            CalculatedSubCharacteristic.objects.create(
-                value=0.1,
-                subcharacteristic=sub_char,
-                repository=self.repository,
-            )
+    def test_build_calculated_characteristics_uses_in_memory_values(self):
+        subchar_values = {
+            s.key: 0.1 for s in SupportedSubCharacteristic.objects.all()
+        }
+        char_keys = [
+            c.key for c in self.release_config.get_characteristics_qs()
+        ]
 
-        keys = [characteristic.key for characteristic in qs]
-        char = self.services.calculcate_characterisctics(
-            characteristics_keys=keys,
-            release_configuration=self.release_config
+        instances, values = self.services.build_calculated_characteristics(
+            char_keys, self.release_config, subchar_values,
         )
-        assert char == dicts.CHAR_RESPONSE
 
-    def test_if_calculate_tsqmi_is_working(self):
-        for char in SupportedCharacteristic.objects.all():
-            CalculatedCharacteristic.objects.create(
-                value=0.1, characteristic=char, repository=self.repository
-            )
+        assert CalculatedCharacteristic.objects.count() == 0
+        assert len(instances) == len(char_keys)
+        assert all(isinstance(i, CalculatedCharacteristic) for i in instances)
+        assert all(i.pk is None for i in instances)
+        assert set(values.keys()) == set(char_keys)
 
-        tsqmi = self.services.calculate_tsqmi(self.release_config)
-        assert tsqmi == {'id': 1, 'value': 0.1, 'created_at': '2024-09-08T17:00:00-03:00'}
+    def test_build_tsqmi_returns_unsaved_instance(self):
+        char_values = {
+            c.key: 0.1 for c in SupportedCharacteristic.objects.all()
+        }
+
+        tsqmi = self.services.build_tsqmi(self.release_config, char_values)
+
+        assert TSQMI.objects.count() == 0
+        assert isinstance(tsqmi, TSQMI)
+        assert tsqmi.pk is None
+        assert tsqmi.repository == self.repository
+        assert isinstance(tsqmi.value, float)
+
+    def test_persist_all_writes_in_one_transaction(self):
+        """persist_all envolve as 5 camadas em transaction.atomic e
+        retorna serializers."""
+        collected = self._build_collected_metrics_for_all_measures()
+        measure_keys = [m.key for m in SupportedMeasure.objects.all()]
+        subchar_keys = [
+            s.key for s in self.release_config.get_subcharacteristics_qs()
+        ]
+        char_keys = [
+            c.key for c in self.release_config.get_characteristics_qs()
+        ]
+
+        measures, measure_values = self.services.build_calculated_measures(
+            measure_keys, self.release_config, collected,
+        )
+        subchars, subchar_values = self.services.build_calculated_subcharacteristics(
+            subchar_keys, self.release_config, measure_values,
+        )
+        chars, char_values = self.services.build_calculated_characteristics(
+            char_keys, self.release_config, subchar_values,
+        )
+        tsqmi = self.services.build_tsqmi(self.release_config, char_values)
+
+        response = self.services.persist_all(
+            collected, measures, subchars, chars, tsqmi,
+        )
+
+        # Tudo persistido
+        assert CollectedMetric.objects.count() == len(collected)
+        assert CalculatedMeasure.objects.count() == len(measures)
+        assert CalculatedSubCharacteristic.objects.count() == len(subchars)
+        assert CalculatedCharacteristic.objects.count() == len(chars)
+        assert TSQMI.objects.count() == 1
+
+        # Resposta tem as 5 chaves serializadas
+        for key in ('metrics', 'measures', 'subcharacteristics',
+                    'characteristics', 'tsqmi'):
+            assert key in response

--- a/src/math_model/views.py
+++ b/src/math_model/views.py
@@ -1,42 +1,56 @@
-from math_model.serializer import MetricsSerializer
-from rest_framework import mixins, viewsets, status
-from math_model.services import MathModelServices
+from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response
-from django.db import transaction
+
+from math_model.services import MathModelServices
+from release_configuration.serializers import ReleaseConfigurationSerializer
 from utils import utils
 from utils.exceptions import CalculateModelException
+
 from .utils import parse_release_configuration
-from release_configuration.serializers import ReleaseConfigurationSerializer
 
 
 class CalculateMathModelViewSet(
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
 ):
-    """
-    ViewSet para cálculo do modelo matematico do MeasureSoftGram
-    """
+    """ViewSet para cálculo do modelo matemático do MeasureSoftGram."""
 
     def create(self, request, *args, **kwargs):
-        repository_id = self.kwargs['repository_pk']
-        product_id = self.kwargs['product_pk']
-        organization_id = self.kwargs['organization_pk']
-        repository = utils.get_repository(organization_id, product_id, repository_id)
-        product = utils.get_product(organization_id, product_id)
+        repository = utils.get_repository(
+            self.kwargs['organization_pk'],
+            self.kwargs['product_pk'],
+            self.kwargs['repository_pk'],
+        )
+        product = utils.get_product(
+            self.kwargs['organization_pk'],
+            self.kwargs['product_pk'],
+        )
         services = MathModelServices(repository, product)
 
         release_configuration = product.release_configuration.first()
         config_serializer = ReleaseConfigurationSerializer(release_configuration)
-        char_keys, subchar_keys, measure_keys = parse_release_configuration(config_serializer.data)
+        char_keys, subchar_keys, measure_keys = parse_release_configuration(
+            config_serializer.data,
+        )
 
-        response = {}
         try:
-            with transaction.atomic():
-                response["metrics"] = services.collect_metrics(request.data)
-                response["measures"] = services.calculate_measures(measure_keys, release_configuration)
-                response["subcharacteristics"] = services.calculate_sucharacteristics(subchar_keys, release_configuration)
-                response["characteristics"] = services.calculcate_characterisctics(char_keys, release_configuration)
-                response["tsqmi"] = services.calculate_tsqmi(release_configuration)
+            # Fase 1: cálculo em memória — sem locks de banco.
+            collected_metrics = services.build_collected_metrics(request.data)
+            measures, measure_values = services.build_calculated_measures(
+                measure_keys, release_configuration, collected_metrics,
+            )
+            subchars, subchar_values = services.build_calculated_subcharacteristics(
+                subchar_keys, release_configuration, measure_values,
+            )
+            chars, char_values = services.build_calculated_characteristics(
+                char_keys, release_configuration, subchar_values,
+            )
+            tsqmi = services.build_tsqmi(release_configuration, char_values)
+
+            # Fase 2: persistência atômica — uma única transação curta.
+            response = services.persist_all(
+                collected_metrics, measures, subchars, chars, tsqmi,
+            )
         except CalculateModelException as exc:
             return Response(
                 {'error': str(exc)},

--- a/src/math_model/views.py
+++ b/src/math_model/views.py
@@ -2,6 +2,7 @@ from math_model.serializer import MetricsSerializer
 from rest_framework import mixins, viewsets, status
 from math_model.services import MathModelServices
 from rest_framework.response import Response
+from django.db import transaction
 from utils import utils
 from utils.exceptions import CalculateModelException
 from .utils import parse_release_configuration
@@ -30,11 +31,12 @@ class CalculateMathModelViewSet(
 
         response = {}
         try:
-            response["metrics"] = services.collect_metrics(request.data)
-            response["measures"] = services.calculate_measures(measure_keys, release_configuration)
-            response["subcharacteristics"] = services.calculate_sucharacteristics(subchar_keys, release_configuration)
-            response["characteristics"] = services.calculcate_characterisctics(char_keys, release_configuration)
-            response["tsqmi"] = services.calculate_tsqmi(release_configuration)
+            with transaction.atomic():
+                response["metrics"] = services.collect_metrics(request.data)
+                response["measures"] = services.calculate_measures(measure_keys, release_configuration)
+                response["subcharacteristics"] = services.calculate_sucharacteristics(subchar_keys, release_configuration)
+                response["characteristics"] = services.calculcate_characterisctics(char_keys, release_configuration)
+                response["tsqmi"] = services.calculate_tsqmi(release_configuration)
         except CalculateModelException as exc:
             return Response(
                 {'error': str(exc)},


### PR DESCRIPTION
## Summary

Resolve US12 (Service refactor): cálculo do modelo matemático passa a ser feito **em memória** a partir do payload da Action, e a persistência das 5 camadas acontece em **uma única transação atômica** no fim. Elimina o estado parcialmente calculado em caso de falha mid-cálculo e a janela de 20min em `metrics/models.py:113`.

Cobre os 3 cenários da US:
- **Cenário 1** — atomicidade do salvamento (`@transaction.atomic` em `persist_all`).
- **Cenário 2** — falha mid-cálculo deixa zero rastros no banco.
- **Cenário 3** — métricas multifatoriais vêm do payload, sem janela de 20min.

Resolve de quebra [#9](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Service/issues/9) (write/read TRK/FIL inconsistente para métricas GitHub) — `_resolve_metric_params_in_memory` filtra `qualifier='TRK'` coerente com a escrita.

## Commits (TDD red → green encadeado)

| # | SHA | Tipo | O que fez |
|---|---|---|---|
| 1 | `5dbfab7` | test (red) | smoke do cenário 2: mocka `calculate_subcharacteristics` no passo 3 e asserta rollback. Falha hoje. |
| 2 | `d79b8c9` | fix | envolve o `try` em `with transaction.atomic()`. Smoke vira green. |
| 3 | `3e25e93` | test (green) | smoke do cenário 1 (fluxo feliz) como rede de proteção pré-refactor. |
| 4 | `9ba9c01` | test (red) | smoke do cenário 3: spy em `SupportedMetric.get_latest_metric_value` espera 0 chamadas. Falha hoje (14 chamadas). |
| 5 | `4a28248` | refactor | reescreve `MathModelServices` em fases `build_* → persist_all`. Smoke vira green. |

Cada commit é auto-contido — bisectável, revisável separadamente.

## Arquitetura nova

**Antes:** 5 `bulk_create` intercalados com chamadas ao msgram-core, cada um em sua TX implícita. Cada `calculate_*` lê do banco com janela de 20min.

**Depois:**
\`\`\`
view.create()
├─ # Fase 1 — em memória, sem locks
├─ collected = services.build_collected_metrics(data)
├─ measures, mvals = services.build_calculated_measures(..., collected)
├─ subchars, svals = services.build_calculated_subcharacteristics(..., mvals)
├─ chars, cvals = services.build_calculated_characteristics(..., svals)
├─ tsqmi = services.build_tsqmi(..., cvals)
│
└─ # Fase 2 — persistência atômica
   response = services.persist_all(collected, measures, subchars, chars, tsqmi)
\`\`\`

`persist_all` decorado com `@transaction.atomic`. Helpers privados (`_resolve_metric_params_in_memory`, `_resolve_measure_params_in_memory`, `_resolve_subcharacteristic_params_in_memory`) substituem leituras do banco. Os métodos `get_latest_*_params` nos models continuam existindo — são usados por `releases/jobs.py:68` (cron job).

## Test plan

- [x] `test_falha_no_passo_3_deve_reverter_passos_anteriores` — cenário 2 (mock força falha mid-cálculo, assert rollback total)
- [x] `test_fluxo_post_nao_le_collected_metric_do_banco` — cenário 3 (spy em `get_latest_metric_value`, assert 0 chamadas)
- [x] `test_fluxo_feliz_persiste_todas_as_camadas` — cenário 1 (payload completo realista, assert 201 + shape + contagens)
- [x] `test_services.py` reescrito pra nova API — 5 testes unitários do `build_*` + `persist_all`
- [x] Suíte completa: **121 passed, 0 failed** (`docker compose exec -w /src service /app/.venv/bin/pytest`)

## Como testar localmente

\`\`\`bash
docker compose up -d
docker compose exec -w /src service /app/.venv/bin/pytest math_model/tests/test_atomicity_smoke.py -vv
docker compose exec -w /src service /app/.venv/bin/pytest
\`\`\`

## Out of scope

- **`msgram-core 1.4.9 → 1.5.3`** — risco pré-existente, sem relação com este refactor. PR próprio.
- **Limpar `metrics/models.py:get_latest_metric_value/values`** — continuam usadas por endpoints `latest-values/` e cron de releases. Sair do fluxo do POST não significa código morto.
- **Janela de 20min em si** — continua viva em `get_latest_metric_values` para usos legítimos (latest-values pode/deve agrupar por rodada). Apenas saiu do fluxo do POST onde era inadequada.