### PR TITLE
Mudança do endpoint gerador da badge TSQMI

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -25,6 +25,7 @@ METRICS_SONAR = [
 BASE_URL_SONAR = 'https://sonarcloud.io/api/measures/component_tree?component=fga-eps-mds_'
 OWNER = "fga-eps-mds"
 
+
 def save_sonar_metrics(tag):
     response = requests.get(f'{BASE_URL_SONAR}{REPO}&metricKeys={",".join(METRICS_SONAR)}&ps=500')
 
@@ -40,10 +41,11 @@ def save_sonar_metrics(tag):
 
     return
 
+
 def all_request_pages(data):
     total_runs = data["total_count"]
     pages = (total_runs // 100) + (1 if total_runs % 100 > 0 else 0)
-    for i in range(pages+1):
+    for i in range(pages + 1):
         if i == 0 or i == 1:
             continue
         api_url_now = api_url_runs + "?page=" + str(i)
@@ -52,15 +54,17 @@ def all_request_pages(data):
             data['workflow_runs'].append(j)
     return data
 
+
 def filter_request_per_date(data, date):
     data_filtered = []
     for i in data["workflow_runs"]:
-        if datetime.strptime(i["created_at"][:10],"%Y-%m-%d").strftime("%Y-%m-%d") == date:
+        if datetime.strptime(i["created_at"][:10], "%Y-%m-%d").strftime("%Y-%m-%d") == date:
             data_filtered.append(i)
     return {"workflow_runs": data_filtered}
 
+
 def save_github_metrics_runs():
-    response = requests.get(api_url_runs, params={'per_page': 100,})
+    response = requests.get(api_url_runs, params={'per_page': 100})
 
     data = response.json()
 
@@ -77,6 +81,7 @@ def save_github_metrics_runs():
         fp.close()
 
     return
+
 
 def save_github_metrics_issues():
     issues = []
@@ -106,6 +111,7 @@ def save_github_metrics_issues():
     # Salvar todas as issues em um arquivo JSON
     with open(file_path, 'w') as fp:
         json.dump(issues, fp, indent=4)
+
 
 if __name__ == '__main__':
 

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -307,3 +307,6 @@ CREATE_FAKE_DATA = os.getenv("CREATE_FAKE_DATA", "False").lower() in (
     "t",
     "1",
 )
+
+# Maximum number of days without a new TSQMI calculation before the badge shows "N/A".
+BADGE_STALENESS_DAYS = int(os.getenv("BADGE_STALENESS_DAYS", "30"))

--- a/src/tsqmi/tests.py
+++ b/src/tsqmi/tests.py
@@ -145,6 +145,3 @@ class LatestCalculatedTSQMIBadgeViewSetTest(APITestCaseExpanded):
         response = self.client.get(self._get_badge_url())
         content = response.content.decode()
         self.assertIn('>A<', content)
-
-
-

--- a/src/tsqmi/tests.py
+++ b/src/tsqmi/tests.py
@@ -1,0 +1,150 @@
+from datetime import timedelta
+
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from tsqmi.models import TSQMI
+from utils.tests import APITestCaseExpanded
+
+
+class LatestCalculatedTSQMIBadgeViewSetTest(APITestCaseExpanded):
+    """Tests for the public SVG badge endpoint."""
+
+    def setUp(self):
+        self.org = self.get_organization()
+        self.product = self.get_product(self.org)
+        self.repository = self.get_repository(self.product)
+        self.client = APIClient()
+
+    def _get_badge_url(self):
+        return reverse(
+            'latest-calculated-tsqmi-badge-list',
+            args=[self.org.id, self.product.id, self.repository.id],
+        )
+
+    def _create_tsqmi(self, value):
+        return TSQMI.objects.create(
+            value=value,
+            repository=self.repository,
+        )
+
+    def test_badge_returns_svg_content_type(self):
+        self._create_tsqmi(0.85)
+        response = self.client.get(self._get_badge_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['Content-Type'], 'image/svg+xml')
+
+    def test_badge_no_authentication_required(self):
+        """Badge endpoint must be public (no auth required)."""
+        self._create_tsqmi(0.5)
+        response = self.client.get(self._get_badge_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_badge_grade_a(self):
+        self._create_tsqmi(0.90)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>A<', content)
+        self.assertIn('#4c1', content)
+
+    def test_badge_grade_b(self):
+        self._create_tsqmi(0.70)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>B<', content)
+        self.assertIn('#97CA00', content)
+
+    def test_badge_grade_c(self):
+        self._create_tsqmi(0.50)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>C<', content)
+        self.assertIn('#dfb317', content)
+
+    def test_badge_grade_d(self):
+        self._create_tsqmi(0.30)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>D<', content)
+        self.assertIn('#fe7d37', content)
+
+    def test_badge_grade_e(self):
+        self._create_tsqmi(0.10)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>E<', content)
+        self.assertIn('#e05d44', content)
+
+    def test_badge_boundary_080_is_grade_a(self):
+        self._create_tsqmi(0.80)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>A<', content)
+
+    def test_badge_boundary_060_is_grade_b(self):
+        self._create_tsqmi(0.60)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>B<', content)
+
+    def test_badge_boundary_040_is_grade_c(self):
+        self._create_tsqmi(0.40)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>C<', content)
+
+    def test_badge_boundary_020_is_grade_d(self):
+        self._create_tsqmi(0.20)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>D<', content)
+
+    def test_badge_no_tsqmi_returns_na(self):
+        """When no TSQMI has been calculated, return N/A badge."""
+        response = self.client.get(self._get_badge_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn('N/A', content)
+        self.assertEqual(response['Content-Type'], 'image/svg+xml')
+
+    def test_badge_contains_measuresoftgram_label(self):
+        self._create_tsqmi(0.75)
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('MeasureSoftGram', content)
+
+    @override_settings(BADGE_STALENESS_DAYS=30)
+    def test_badge_stale_tsqmi_returns_na(self):
+        """When the latest TSQMI is older than BADGE_STALENESS_DAYS, return N/A."""
+        tsqmi = self._create_tsqmi(0.90)
+        tsqmi.created_at = timezone.now() - timedelta(days=31)
+        tsqmi.save()
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('N/A', content)
+
+    @override_settings(BADGE_STALENESS_DAYS=30)
+    def test_badge_fresh_tsqmi_returns_grade(self):
+        """When the latest TSQMI is recent, return the grade normally."""
+        tsqmi = self._create_tsqmi(0.90)
+        tsqmi.created_at = timezone.now() - timedelta(days=29)
+        tsqmi.save()
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>A<', content)
+
+    @override_settings(BADGE_STALENESS_DAYS=0)
+    def test_badge_staleness_disabled_with_zero(self):
+        """When BADGE_STALENESS_DAYS=0, staleness check is disabled."""
+        tsqmi = self._create_tsqmi(0.90)
+        tsqmi.created_at = timezone.now() - timedelta(days=365)
+        tsqmi.save()
+        response = self.client.get(self._get_badge_url())
+        content = response.content.decode()
+        self.assertIn('>A<', content)
+
+
+

--- a/src/tsqmi/views.py
+++ b/src/tsqmi/views.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
 from resources import calculate_tsqmi
 from rest_framework import mixins, status, viewsets
 from rest_framework.generics import get_object_or_404
@@ -46,6 +50,46 @@ class LatestCalculatedTSQMIBadgeViewSet(
     viewsets.GenericViewSet,
 ):
     serializer_class = TSQMISerializer
+    permission_classes = []
+    authentication_classes = []
+
+    GRADE_MAP = [
+        (0.80, 'A', '#4c1'),
+        (0.60, 'B', '#97CA00'),
+        (0.40, 'C', '#dfb317'),
+        (0.20, 'D', '#fe7d37'),
+        (0.00, 'E', '#e05d44'),
+    ]
+
+    BADGE_SVG_TEMPLATE = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="158" height="20">'
+        '<linearGradient id="a" x2="0" y2="100%">'
+        '<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>'
+        '<stop offset="1" stop-opacity=".1"/>'
+        '</linearGradient>'
+        '<rect rx="3" width="158" height="20" fill="#555"/>'
+        '<rect rx="3" x="128" width="30" height="20" fill="{color}"/>'
+        '<path fill="{color}" d="M128 0h4v20h-4z"/>'
+        '<rect rx="3" width="158" height="20" fill="url(#a)"/>'
+        '<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,'
+        'Verdana,Geneva,sans-serif" font-size="11">'
+        '<text x="65" y="15" fill="#010101" fill-opacity=".3">'
+        'MeasureSoftGram</text>'
+        '<text x="65" y="14">MeasureSoftGram</text>'
+        '<text x="143" y="15" fill="#010101" fill-opacity=".3">{grade}</text>'
+        '<text x="143" y="14">{grade}</text>'
+        '</g>'
+        '</svg>'
+    )
+
+    BADGE_STALE_SVG = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="158" height="20">'
+        '<rect rx="3" width="158" height="20" fill="#9f9f9f"/>'
+        '<g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,'
+        'Verdana,Geneva,sans-serif" font-size="11">'
+        '<text x="79" y="14">MeasureSoftGram N/A</text>'
+        '</g></svg>'
+    )
 
     def get_repository(self):
         return get_object_or_404(
@@ -55,28 +99,32 @@ class LatestCalculatedTSQMIBadgeViewSet(
             product__organization_id=self.kwargs["organization_pk"],
         )
 
-    def set_stars(self, valor):
-        if 0 < valor < 0.2:
-            star = 1
-        elif 0.2 <= valor < 0.4:
-            star = 2
-        elif 0.4 <= valor < 0.6:
-            star = 3
-        elif 0.6 <= valor < 0.8:
-            star = 4
-        elif 0.8 <= valor <= 1.0:
-            star = 5
-        else:
-            star = 6
-        return star
+    def get_grade(self, value):
+        for threshold, grade, color in self.GRADE_MAP:
+            if value >= threshold:
+                return grade, color
+        return 'E', '#e05d44'
+
+    def is_stale(self, tsqmi):
+        """Return True if the TSQMI is older than the configured max age."""
+        max_age_days = settings.BADGE_STALENESS_DAYS
+        if max_age_days is None or max_age_days <= 0:
+            return False
+        return timezone.now() - tsqmi.created_at > timedelta(days=max_age_days)
 
     def list(self, request, *args, **kwargs):
         repository = self.get_repository()
         latest_tsqmi = repository.calculated_tsqmis.first()
-        result = self.set_stars(latest_tsqmi.value)
 
-        svg_data = open(f'/src/tsqmi/media/{result}stars.svg', "rb").read()
-        return HttpResponse(svg_data, content_type="image/svg+xml")
+        if latest_tsqmi is None or self.is_stale(latest_tsqmi):
+            return HttpResponse(
+                self.BADGE_STALE_SVG,
+                content_type="image/svg+xml",
+            )
+
+        grade, color = self.get_grade(latest_tsqmi.value)
+        svg = self.BADGE_SVG_TEMPLATE.format(grade=grade, color=color)
+        return HttpResponse(svg, content_type="image/svg+xml")
 
 
 class CalculatedTSQMIHistoryModelViewSet(


### PR DESCRIPTION
# Endpoint público de Badge SVG com nota de qualidade

## Descrição
Implementa o endpoint público que retorna uma badge SVG dinâmica com o grau de qualidade (A–E) do repositório, baseado no índice TSQMI. Também adiciona lógica de expiração: se a última análise tem mais de 30 dias, a badge exibe "N/A".

## Porque este Pull Request é necessário?
Atualmente não existe uma forma de exibir a nota de qualidade de um repositório diretamente no README via badge. Este PR cria o endpoint que permite incorporar uma badge dinâmica em qualquer documento Markdown, seguindo o padrão visual do shields.io com graus A–E coloridos.

## Critérios de aceitação

1. [x] Endpoint `GET .../latest-values/tsqmi/badge/` retorna SVG válido com content-type `image/svg+xml`
2. [x] Endpoint é público (sem autenticação necessária)
3. [x] Badge exibe grau A (verde), B (lima), C (amarelo), D (laranja) ou E (vermelho) conforme faixas do TSQMI
4. [x] Badge exibe "N/A" cinza quando não há TSQMI calculado
5. [x] Badge exibe "N/A" cinza quando o TSQMI está desatualizado (>30 dias, configurável via `BADGE_STALENESS_DAYS`)
6. [x] Testes unitários cobrindo todos os graus, fronteiras, expiração e caso sem dados

## Mudanças realizadas

- **`src/tsqmi/views.py`** — Refatorou `LatestCalculatedTSQMIBadgeViewSet`: geração dinâmica de SVG com grau A–E, endpoint público, lógica de expiração
- **`src/tsqmi/tests.py`** — 16 testes cobrindo graus, fronteiras, staleness e N/A
- **`src/config/settings/base.py`** — Adicionada configuração `BADGE_STALENESS_DAYS`
