### PR TITLE
feat(deploy): producao na box LAPPIS (gunicorn, compose, runner self-hosted)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,80 @@
+name: Deploy Prod (self-hosted)
+
+# Deploy de producao na box LAPPIS via runner self-hosted instalado nela.
+# A box so PUXA imagens buildadas no CI (docker-publish.yml), nao builda.
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Pull + up + smoke
+    runs-on: [self-hosted, msgram-prod]
+
+    env:
+      COMPOSE_FILE: deploy/docker-compose.prod.yml
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login no DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull das imagens
+        run: docker compose -f "$COMPOSE_FILE" pull
+
+      - name: Subir a stack
+        run: docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
+
+      - name: Migrate (idempotente)
+        run: |
+          docker compose -f "$COMPOSE_FILE" exec -T service \
+            python manage.py migrate --noinput
+
+      - name: Smoke test
+        run: |
+          set -e
+          ok=0
+          for i in $(seq 1 15); do
+            if curl -fsS http://localhost/swagger/ >/dev/null; then
+              ok=1; break
+            fi
+            echo "swagger ainda nao respondeu (tentativa $i), aguardando..."
+            sleep 4
+          done
+          if [ "$ok" != "1" ]; then
+            echo "FALHA: /swagger/ nao respondeu 200"
+            exit 1
+          fi
+          echo "OK: /swagger/ 200"
+
+          # Rota viva da API: 401 (auth) ou 200 e sucesso; 000/502 e falha.
+          api_code=$(curl -s -o /dev/null -w '%{http_code}' \
+            http://localhost/api/v1/supported-metrics/ || echo 000)
+          echo "API /supported-metrics/ -> $api_code"
+          case "$api_code" in
+            200|401|403) echo "OK: API viva" ;;
+            *) echo "FALHA: API code $api_code"; exit 1 ;;
+          esac
+
+          # Front responde na raiz.
+          if curl -fsS http://localhost/ >/dev/null; then
+            echo "OK: Front 200"
+          else
+            echo "FALHA: Front nao respondeu na raiz"
+            exit 1
+          fi
+
+      - name: Logs em caso de falha
+        if: failure()
+        run: docker compose -f "$COMPOSE_FILE" logs --tail=120

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,8 +1,11 @@
-name: Deploy Service
+name: Deploy Service (EC2 legado - DESATIVADO)
 
+# DESATIVADO: a producao migrou para a box LAPPIS (deploy-prod.yml).
+# O trigger automatico em push develop foi removido para o deploy do EC2
+# (epsmsg.shop) nao competir com o novo deploy. Mantido como
+# workflow_dispatch para rollback manual de emergencia ao EC2, se preciso.
 on:
-  push:
-    branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   Deploy:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,13 @@
 name: Publish Docker Image
 
+# Builda a imagem do Service no CI cloud (ubuntu-latest) e publica no
+# DockerHub. A box de producao so faz PULL (deploy-prod.yml), nunca build.
+# Publica em push pra develop pra garantir imagem fresca a cada merge.
 on:
-  pull_request:
+  push:
     branches:
       - develop
-    types:
-      - closed
+  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -27,4 +29,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/service:latest
+          # latest pra deploy simples + sha pra rollback/deploy deterministico.
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/service:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/service:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,10 @@ COPY --from=builder /app/.venv /app/.venv
 
 # Copiar código
 COPY src /src/
+
+# Garantir bit de execucao do entrypoint (necessario quando a imagem roda
+# por conta propria, ex: `docker compose pull` + up sem command no compose).
+RUN chmod +x /src/start_service.sh
+
+# Entrypoint default: migra, collectstatic e sobe gunicorn (ver script).
+CMD ["./start_service.sh"]

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,93 @@
+# ============================================================
+# docker-compose.prod.yml: orquestracao de producao do MeasureSoftGram.
+#
+# Topologia: proxy nginx interno publica :80 no host e roteia /api,
+# /swagger, /admin, /static -> service:8080 e / -> front:3000. db e
+# service NAO publicam porta (so rede interna do compose).
+#
+# Deploy: PULL das imagens buildadas no CI (a box so puxa, nao builda).
+#   docker compose -f deploy/docker-compose.prod.yml pull
+#   docker compose -f deploy/docker-compose.prod.yml up -d
+#
+# Variaveis lidas do ambiente / arquivo .env ao lado deste compose:
+#   DOCKERHUB_USERNAME  -> namespace das imagens service/front
+#   SERVICE_IMAGE_TAG   -> tag da imagem do service  (default: latest)
+#   FRONT_IMAGE_TAG     -> tag da imagem do front    (default: latest)
+# Segredos das apps vivem em ./env-vars/*.env (gitignored), provisionados
+# na box, nunca no repo.
+# ============================================================
+
+volumes:
+  service_postgres_data:
+
+networks:
+  msgram:
+    driver: bridge
+
+services:
+  db:
+    container_name: msgram_db
+    image: postgres:18-alpine
+    volumes:
+      # pg18 usa PGDATA em .../data: montar o subdir /data, nao a raiz,
+      # senao os dados nao persistem corretamente entre `compose up`.
+      - service_postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ./env-vars/.postgres.env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - msgram
+    restart: unless-stopped
+
+  service:
+    container_name: msgram_service
+    image: ${DOCKERHUB_USERNAME}/service:${SERVICE_IMAGE_TAG:-latest}
+    env_file:
+      - ./env-vars/.service.env
+      - ./env-vars/.postgres.env
+    environment:
+      DJANGO_SETTINGS_MODULE: config.settings.production
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      # /swagger e AllowAny -> 200 quando o app esta de pe.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/swagger/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+    networks:
+      - msgram
+    restart: unless-stopped
+
+  front:
+    container_name: msgram_front
+    image: ${DOCKERHUB_USERNAME}/front:${FRONT_IMAGE_TAG:-latest}
+    # env do front (ex: URL publica da API) provisionado pelo time de Front
+    # em ./env-vars/.front.env se necessario.
+    depends_on:
+      - service
+    networks:
+      - msgram
+    restart: unless-stopped
+
+  proxy:
+    container_name: msgram_proxy
+    image: nginx:1.27-alpine
+    # Proxy INTERNO da stack: publica :80 do host. O proxy externo da box
+    # (openresty) fica na frente e encaminha o dominio pra esta :80.
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - service
+      - front
+    networks:
+      - msgram
+    restart: unless-stopped

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,61 @@
+# ============================================================
+# Reverse proxy INTERNO da stack MeasureSoftGram.
+# Roteia o backend (service) e o frontend (front) sob o mesmo host.
+# Fica atras do proxy externo da box (openresty), que termina o dominio.
+# ============================================================
+
+upstream msgram_service {
+    server service:8080;
+}
+
+upstream msgram_front {
+    server front:3000;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    # Payload de metricas pode ser grande (DATA_UPLOAD_MAX_NUMBER_FIELDS alto).
+    client_max_body_size 50m;
+
+    # --- Backend Django (DRF) ---
+    location /api/ {
+        proxy_pass http://msgram_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+
+    location /swagger/ {
+        proxy_pass http://msgram_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /admin/ {
+        proxy_pass http://msgram_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Estaticos do Django servidos pelo WhiteNoise no proprio service.
+    location /static/ {
+        proxy_pass http://msgram_service;
+        proxy_set_header Host $host;
+    }
+
+    # --- Frontend (Next.js) ---
+    location / {
+        proxy_pass http://msgram_front;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+}

--- a/env-vars-example/.postgres.env
+++ b/env-vars-example/.postgres.env
@@ -2,4 +2,6 @@ POSTGRES_HOST=db
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PORT=5432
+# Dev: senha trivial. PROD: gerar senha forte no arquivo real
+# env-vars/.postgres.env (gitignored) e guardar no cofre. Nunca commitar.
 POSTGRES_PASSWORD=postgres

--- a/env-vars-example/.service.env
+++ b/env-vars-example/.service.env
@@ -1,3 +1,6 @@
+# ============================================================
+# DEV (default local). Copie env-vars-example -> env-vars e ajuste.
+# ============================================================
 DEBUG=TRUE
 CREATE_FAKE_DATA=TRUE
 
@@ -6,3 +9,31 @@ GITHUB_CLIENT_ID=CL13NT1D
 GITHUB_SECRET=S3CR3T
 SECRET_KEY=django-insecure-9(nkl$g75ia=@q3p*s83rc9y=q5=!q@kr8+s3*xc-t441#jmg%
 AMBIENT_TEST_OR_DEV=TRUE
+
+# ============================================================
+# PROD (referencia). Em producao, sobrescrever as chaves abaixo no
+# arquivo real env-vars/.service.env (gitignored) com valores reais.
+# NUNCA commitar segredo aqui, so placeholders.
+# ============================================================
+# DJANGO_SETTINGS_MODULE=config.settings.production
+# DEBUG=FALSE
+# CREATE_FAKE_DATA=FALSE
+# AMBIENT_TEST_OR_DEV=FALSE
+# SECRET_KEY=<<gerar-em-prod: get_random_secret_key()>>
+# ALLOWED_HOSTS=msgram.lappis.rocks,service,localhost
+# CSRF_TRUSTED_ORIGINS=http://msgram.lappis.rocks
+# FRONTEND_PROD_URL=http://msgram.lappis.rocks
+# LOGIN_REDIRECT_URL=http://msgram.lappis.rocks
+# GITHUB_CLIENT_ID=<<oauth-app-client-id>>
+# GITHUB_SECRET=<<oauth-app-secret>>
+# Seguranca: tudo OFF por default (porta 80 sem TLS). Ligar quando houver TLS na borda.
+# SECURE_SSL_REDIRECT=FALSE
+# SECURE_HSTS_SECONDS=0
+# SESSION_COOKIE_SECURE=FALSE
+# CSRF_COOKIE_SECURE=FALSE
+# USE_X_FORWARDED_PROTO=TRUE
+# USE_X_FORWARDED_HOST=TRUE
+# Entrypoint / gunicorn:
+# RUN_LOAD_INITIAL_DATA=true
+# GUNICORN_WORKERS=3
+# GUNICORN_TIMEOUT=120

--- a/src/config/settings/production.py
+++ b/src/config/settings/production.py
@@ -1,26 +1,46 @@
 """
 Production settings — DJANGO_SETTINGS_MODULE=config.settings.production
 
-DEBUG=False forcado. Headers de seguranca: HSTS, SSL redirect, cookies
-secure-only, XFO=DENY. Backward-compatible com env vars existentes do
-deploy EC2 (SECRET_KEY, ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS,
-POSTGRES_*, GITHUB_*).
+DEBUG=False forcado. Headers de seguranca (HSTS, SSL redirect, cookies
+secure-only) sao PARAMETRIZADOS por env e vem DESLIGADOS por default,
+porque o deploy atras de proxy HTTP plano (sem TLS na box) quebra com
+SSL redirect forcado: o Django responde HTTP interno e um redirect pra
+https sem certificado vira loop, e o HSTS gravado no browser trava o
+acesso futuro. Quando houver TLS na borda, ligar via env. Backward-
+compatible com env vars existentes (SECRET_KEY, ALLOWED_HOSTS,
+CSRF_TRUSTED_ORIGINS, POSTGRES_*, GITHUB_*).
 """
+
+import os
 
 from .base import *  # noqa: F401,F403
 
 
+def _env_flag(name, default="False"):
+    return os.getenv(name, default).lower() in ("true", "t", "1", "yes")
+
+
 DEBUG = False
 
-# HTTPS / cookies
-SECURE_SSL_REDIRECT = True
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
+# HTTPS / cookies: todos OFF por default (porta 80 sem TLS na box).
+# Ligar via env quando houver terminacao TLS na borda.
+SECURE_SSL_REDIRECT = _env_flag("SECURE_SSL_REDIRECT", "False")
+SESSION_COOKIE_SECURE = _env_flag("SESSION_COOKIE_SECURE", "False")
+CSRF_COOKIE_SECURE = _env_flag("CSRF_COOKIE_SECURE", "False")
 
-# HSTS: 1 ano, subdomains incluidos, ready pra preload list.
-SECURE_HSTS_SECONDS = 60 * 60 * 24 * 365
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-SECURE_HSTS_PRELOAD = True
+# HSTS: default 0 (desligado). Em prod com TLS, setar p/ 31536000 (1 ano).
+SECURE_HSTS_SECONDS = int(os.getenv("SECURE_HSTS_SECONDS", "0"))
+SECURE_HSTS_INCLUDE_SUBDOMAINS = _env_flag(
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", "False"
+)
+SECURE_HSTS_PRELOAD = _env_flag("SECURE_HSTS_PRELOAD", "False")
+
+# Atras de proxy: confiar no header X-Forwarded-Proto pra detectar https
+# quando o TLS termina na borda. So tem efeito se o proxy setar o header.
+if _env_flag("USE_X_FORWARDED_PROTO", "False"):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+USE_X_FORWARDED_HOST = _env_flag("USE_X_FORWARDED_HOST", "False")
 
 # Clickjacking
 X_FRAME_OPTIONS = "DENY"

--- a/src/releases/jobs.py
+++ b/src/releases/jobs.py
@@ -4,6 +4,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from django_apscheduler.jobstores import DjangoJobStore, register_events
+from django.db import connection
 from django.utils import timezone
 from django_apscheduler.models import DjangoJobExecution
 
@@ -16,6 +17,11 @@ from characteristics.models import (
 )
 
 import sys
+
+# Chave fixa do advisory lock de sessao do Postgres usado para eleger um
+# unico worker como dono do scheduler. Qualquer int de 64 bits estavel
+# serve, contanto que seja o mesmo em todos os workers do mesmo banco.
+SCHEDULER_ADVISORY_LOCK_KEY = 728_945_113
 
 
 def get_releases_and_create_results():
@@ -108,7 +114,46 @@ def get_releases_and_create_results():
                 continue
 
 
+def acquire_scheduler_lock():
+    """Tenta adquirir o advisory lock de sessao do scheduler.
+
+    Com gunicorn multi-worker, releases/apps.py ready() roda uma vez por
+    worker. Sem eleicao de lider, cada worker sobe seu proprio
+    BackgroundScheduler e o cron dispara N vezes (uma por worker),
+    duplicando CalculatedCharacteristic.
+
+    pg_try_advisory_lock retorna True para o primeiro worker (que vira o
+    dono do scheduler) e False para os demais, sem bloquear. O lock e de
+    sessao: enquanto a conexao do worker dono viver, ele segura o lock.
+
+    Retorna True se este worker deve startar o scheduler, False caso
+    contrario. Em bancos que nao suportam advisory lock (ex: sqlite em
+    cenarios fora de producao) cai no fallback de startar (retorna True),
+    preservando o comportamento single-process historico.
+    """
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'SELECT pg_try_advisory_lock(%s)',
+                [SCHEDULER_ADVISORY_LOCK_KEY],
+            )
+            row = cursor.fetchone()
+            return bool(row[0]) if row else False
+    except Exception:
+        # Banco sem suporte a advisory lock: mantem comportamento antigo.
+        # Em prod com >1 worker, use GUNICORN_WORKERS=1 no container do
+        # scheduler como fallback (ver start_service.sh / deploy).
+        return True
+
+
 def check_the_need_to_calculate_releases():
+    if not acquire_scheduler_lock():
+        print(
+            'Scheduler ja iniciado por outro worker, ignorando...',
+            file=sys.stdout,
+        )
+        return
+
     scheduler = BackgroundScheduler()
     scheduler.add_jobstore(DjangoJobStore(), 'default')
 

--- a/src/releases/tests/test_scheduler_lock.py
+++ b/src/releases/tests/test_scheduler_lock.py
@@ -1,0 +1,60 @@
+"""
+Testa o guard de lider unico do scheduler APScheduler.
+
+Com gunicorn multi-worker, releases/apps.py ready() roda uma vez por
+worker. Sem um guard, cada worker sobe seu proprio BackgroundScheduler
+e o cron get_releases_and_create_results dispara N vezes (uma por
+worker), duplicando CalculatedCharacteristic. O guard usa um advisory
+lock de sessao do Postgres (pg_try_advisory_lock): so o worker que
+adquire o lock starta o scheduler.
+"""
+
+from unittest import mock
+
+from django.test import TestCase
+
+from releases import jobs
+
+
+class SchedulerLockTestCase(TestCase):
+    def test_acquire_scheduler_lock_true_when_lock_free(self):
+        """Primeiro worker pega o lock -> deve startar o scheduler."""
+        with mock.patch("releases.jobs.connection") as conn:
+            cursor = (
+                conn.cursor.return_value.__enter__.return_value
+            )
+            cursor.fetchone.return_value = (True,)
+
+            self.assertTrue(jobs.acquire_scheduler_lock())
+
+    def test_acquire_scheduler_lock_false_when_already_held(self):
+        """Workers seguintes nao pegam o lock -> nao sobem scheduler."""
+        with mock.patch("releases.jobs.connection") as conn:
+            cursor = (
+                conn.cursor.return_value.__enter__.return_value
+            )
+            cursor.fetchone.return_value = (False,)
+
+            self.assertFalse(jobs.acquire_scheduler_lock())
+
+    def test_check_the_need_skips_start_when_lock_not_acquired(self):
+        """Sem o lock, check_the_need nao chama scheduler.start()."""
+        with mock.patch(
+            "releases.jobs.acquire_scheduler_lock", return_value=False
+        ), mock.patch(
+            "releases.jobs.BackgroundScheduler"
+        ) as scheduler_cls:
+            jobs.check_the_need_to_calculate_releases()
+            scheduler_cls.return_value.start.assert_not_called()
+
+    def test_check_the_need_starts_when_lock_acquired(self):
+        """Com o lock, check_the_need sobe o scheduler normalmente."""
+        with mock.patch(
+            "releases.jobs.acquire_scheduler_lock", return_value=True
+        ), mock.patch(
+            "releases.jobs.register_events"
+        ), mock.patch(
+            "releases.jobs.BackgroundScheduler"
+        ) as scheduler_cls:
+            jobs.check_the_need_to_calculate_releases()
+            scheduler_cls.return_value.start.assert_called_once()

--- a/src/start_service.sh
+++ b/src/start_service.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# Exporting all environment variables to use in crontab
-env | sed 's/^\(.*\)$/ \1/g' > /root/env
+set -e
 
 # Função que espera o postgres ficar pronto antes de subir o server
 function_postgres_ready() {
@@ -27,13 +25,31 @@ done
 echo "======= POSTGRES IS UP, CONNECTING"
 
 echo '======= RUNNING MIGRATIONS'
-python3 manage.py migrate
+python3 manage.py migrate --noinput
 
-echo '======= PREPOPULATING THE DATABASE'
-python3 manage.py load_initial_data
+# load_initial_data popula entidades suportadas. Em prod, rodar a cada
+# subida pode re-popular/sobrescrever, condicionado por env. Ligar no
+# 1o deploy (RUN_LOAD_INITIAL_DATA=true) e desligar depois.
+if [ "${RUN_LOAD_INITIAL_DATA:-true}" = "true" ]; then
+  echo '======= PREPOPULATING THE DATABASE'
+  python3 manage.py load_initial_data
+else
+  echo '======= SKIPPING load_initial_data (RUN_LOAD_INITIAL_DATA != true)'
+fi
 
 echo '======= COLLECTING STATIC FILES'
 python3 manage.py collectstatic --noinput
 
-echo '======= RUNNING SERVER'
-python3 manage.py runserver 0.0.0.0:8080
+# ATENCAO scheduler: o APScheduler sobe no ready() do AppConfig, uma vez
+# por worker do gunicorn. A eleicao de lider via advisory lock do Postgres
+# (releases/jobs.py:acquire_scheduler_lock) garante que so 1 worker starta
+# o cron mesmo com GUNICORN_WORKERS>1. Se o banco nao suportar advisory
+# lock, force GUNICORN_WORKERS=1.
+echo '======= RUNNING GUNICORN'
+exec gunicorn config.wsgi:application \
+  --chdir /src \
+  --bind 0.0.0.0:8080 \
+  --workers "${GUNICORN_WORKERS:-3}" \
+  --timeout "${GUNICORN_TIMEOUT:-120}" \
+  --access-logfile - \
+  --error-logfile -


### PR DESCRIPTION
## O que muda
Deixa o Service pronto para rodar fixo na maquina do laboratorio, com deploy automatico.

- Entrypoint de producao: gunicorn no lugar do runserver (migrate + collectstatic + workers/timeout por env)
- Dockerfile com CMD proprio (imagem self-contained)
- settings.production: SSL redirect e HSTS parametrizados por env (default desligado, para HTTP na porta 80 atras do proxy)
- Orquestracao em deploy/: docker-compose.prod.yml (Postgres 18-alpine, consistente com o test.yml; service; front; nginx interno na :80) e a config do nginx
- Workflow de deploy via self-hosted runner (docker compose pull + up + smoke test)
- APScheduler: eleicao de lider unico via advisory lock do Postgres (evita jobs duplicados com gunicorn multi-worker)
- Desativa o deploy legado para EC2

## Testes
- pytest: 145 passando
- Ciclo TDD do advisory lock em commits separados (test RED, fix GREEN)

## Observacoes
- Variaveis de producao reais vivem na maquina (env-vars/ gitignored), nunca no repo
- Secrets de CI necessarios: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
