### PR TITLE
fix(deploy): provisiona env-vars de producao antes de subir a stack

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,6 +24,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Os segredos das apps vivem provisionados na box (fora do repo, fora do
+      # checkout efemero). Copia eles pro lugar que o compose espera.
+      - name: Provisionar env-vars de producao
+        run: |
+          mkdir -p deploy/env-vars
+          cp "$MSGRAM_ENV_DIR/.service.env" deploy/env-vars/.service.env
+          cp "$MSGRAM_ENV_DIR/.postgres.env" deploy/env-vars/.postgres.env
+        env:
+          MSGRAM_ENV_DIR: /home/lappis/msgram-env
+
       - name: Login no DockerHub
         uses: docker/login-action@v3
         with:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -29,9 +29,9 @@ services:
     container_name: msgram_db
     image: postgres:18-alpine
     volumes:
-      # pg18 usa PGDATA em .../data: montar o subdir /data, nao a raiz,
-      # senao os dados nao persistem corretamente entre `compose up`.
-      - service_postgres_data:/var/lib/postgresql/data
+      # postgres 18+ guarda os dados num subdir version-specific e exige o mount
+      # na raiz /var/lib/postgresql (a imagem rejeita o mount direto em /data).
+      - service_postgres_data:/var/lib/postgresql
     env_file:
       - ./env-vars/.postgres.env
     healthcheck:


### PR DESCRIPTION
## O que muda
O deploy de producao (`deploy-prod.yml`) subia sem os arquivos de env das apps: o checkout do CI e efemero e os segredos (gitignored) nao vem nele, entao o compose nao achava `.service.env` / `.postgres.env`.

Este PR adiciona um step que copia os env-vars de um diretorio persistente provisionado na box (`/home/lappis/msgram-env/`, fora do repo) para `deploy/env-vars/` antes de subir a stack.

Os segredos reais nunca passam pelo repo nem pelos logs do CI.
