### PR TITLE
fix(deploy): remover migrate redundante que causava race no deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,10 +46,12 @@ jobs:
       - name: Subir a stack
         run: docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 
-      - name: Migrate (idempotente)
-        run: |
-          docker compose -f "$COMPOSE_FILE" exec -T service \
-            python manage.py migrate --noinput
+      # NAO rodar migrate aqui. O proprio boot do container ja migra
+      # (src/start_service.sh roda `manage.py migrate --noinput` antes de
+      # subir o servidor). Um migrate extra por fora corria concorrente com o
+      # do boot, sem lock, e dava race (DuplicateColumn em accounts.0002 ->
+      # "column github_access_token already exists"), reprovando o deploy de
+      # forma intermitente. Migrate fica num lugar so: o entrypoint.
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
## Problema
O job `Deploy Prod (self-hosted)` falhou no step `Migrate (idempotente)` (run #28342909506) com `DuplicateColumn: column "github_access_token" of relation "accounts_customuser" already exists`.

O step rodava `manage.py migrate` por fora, logo apos `docker compose up -d`. So que o boot do container service ja migra: `src/start_service.sh` roda `migrate --noinput` antes de subir o servidor (e o `CMD` da imagem).

Os dois migrates corriam concorrentes, sem lock. Na migration `accounts.0002` (AddField `github_access_token`), um processo criava a coluna e o outro batia `DuplicateColumn`, reprovando o deploy. E intermitente: o mesmo codigo passou as 17:33 e falhou as 01:29, so mudou o timing.

## Fix
Remove o step `Migrate (idempotente)` do workflow. O migrate fica num lugar so: o boot do container. Comentario adicionado no lugar pra nao reintroduzirem a race.

## Nota
A migration `0002` esta correta, nao foi tocada. O problema era a duplicacao do migrate, nao a migration. O proximo deploy apos o merge sera o primeiro teste end-to-end do fix.