### PR TITLE
ci: deploy de prod via SSH (runner cloud) + independente do Front

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,10 +1,28 @@
-name: Deploy Prod (self-hosted)
+name: Deploy Prod (SSH)
 
-# Deploy de producao na box LAPPIS via runner self-hosted instalado nela.
-# A box so PUXA imagens buildadas no CI (docker-publish.yml), nao builda.
+# Deploy de producao na VM do LAPPIS via SSH, a partir de um runner cloud
+# (ubuntu-latest). Antes rodava num self-hosted runner instalado DENTRO da VM;
+# migramos pra SSH porque a VM vai ser isolada da rede do Lab e o unico acesso
+# de entrada passa a ser a porta de firewall (redirect). Saida pra internet
+# continua, entao o runner cloud alcanca o DockerHub e a VM aceita o SSH.
+#
+# A box so PUXA imagens buildadas no docker-publish.yml, nunca builda.
+#
+# Dispara DEPOIS que a imagem do Service e publicada (workflow_run sobre o
+# "Publish Docker Image"), pra nunca dar pull antes da imagem nova existir no
+# DockerHub. Deploy do Service e independente do Front: mexer aqui so redeploya
+# o Service (e atualiza compose/nginx); o Front tem o seu proprio deploy.
+#
+# OBS workflow_run: so dispara quando este arquivo ja esta no branch DEFAULT
+# (develop, confirmado). O proprio merge pra develop ja deixa o arquivo la.
+
 on:
-  push:
-    branches: [develop]
+  workflow_run:
+    workflows: ["Publish Docker Image"]
+    types:
+      - completed
+    branches:
+      - develop
   workflow_dispatch:
 
 concurrency:
@@ -13,80 +31,82 @@ concurrency:
 
 jobs:
   deploy:
-    name: Pull + up + smoke
-    runs-on: [self-hosted, msgram-prod]
-
-    env:
-      COMPOSE_FILE: deploy/docker-compose.prod.yml
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    name: Pull + up + smoke (SSH)
+    runs-on: ubuntu-latest
+    # workflow_dispatch nao tem conclusion; via workflow_run so segue se o
+    # build/publish passou (PR recusado ou build quebrado nao deploya).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - name: Checkout
+      - name: Checkout (compose + nginx)
         uses: actions/checkout@v4
 
-      # Os segredos das apps vivem provisionados na box (fora do repo, fora do
-      # checkout efemero). Copia eles pro lugar que o compose espera.
-      - name: Provisionar env-vars de producao
-        run: |
-          mkdir -p deploy/env-vars
-          cp "$MSGRAM_ENV_DIR/.service.env" deploy/env-vars/.service.env
-          cp "$MSGRAM_ENV_DIR/.postgres.env" deploy/env-vars/.postgres.env
-        env:
-          MSGRAM_ENV_DIR: /home/lappis/msgram-env
-
-      - name: Login no DockerHub
-        uses: docker/login-action@v3
+      # O compose e o nginx vivem neste repo e sao a fonte da verdade da
+      # orquestracao. Subimos a versao fresca pra box a cada deploy do Service.
+      # strip_components: 1 tira o prefixo "deploy/" -> arquivos caem direto em
+      # ~/msgram-deploy/ (docker-compose.prod.yml, nginx/default.conf).
+      # Os env-vars (.service.env / .postgres.env) NAO vem do repo: vivem
+      # provisionados na box em ~/msgram-deploy/env-vars (gitignored, fora do
+      # checkout), configurados uma vez no setup da VM.
+      - name: Enviar compose/nginx pra VM
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ secrets.SSH_KNOWN_HOST_FP }}
+          source: "deploy/docker-compose.prod.yml,deploy/nginx/default.conf"
+          target: "~/msgram-deploy"
+          strip_components: 1
+          overwrite: true
 
-      - name: Pull das imagens
-        run: docker compose -f "$COMPOSE_FILE" pull
+      - name: Deploy (login + pull + up + smoke)
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          fingerprint: ${{ secrets.SSH_KNOWN_HOST_FP }}
+          command_timeout: 15m
+          envs: DOCKERHUB_USERNAME,DOCKERHUB_TOKEN
+          script: |
+            set -e
+            cd ~/msgram-deploy
+            export DOCKERHUB_USERNAME="$DOCKERHUB_USERNAME"
+            echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
-      - name: Subir a stack
-        run: docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
+            # flock serializa deploy do Service e do Front na MESMA box. O
+            # concurrency do Actions e por-repo e nao cria mutex cross-repo;
+            # dois `compose up` simultaneos dao race. O lock fica na box.
+            flock /tmp/msgram-deploy.lock -c '
+              docker compose -f docker-compose.prod.yml pull
+              docker compose -f docker-compose.prod.yml up -d --remove-orphans
+            '
 
-      # NAO rodar migrate aqui. O proprio boot do container ja migra
-      # (src/start_service.sh roda `manage.py migrate --noinput` antes de
-      # subir o servidor). Um migrate extra por fora corria concorrente com o
-      # do boot, sem lock, e dava race (DuplicateColumn em accounts.0002 ->
-      # "column github_access_token already exists"), reprovando o deploy de
-      # forma intermitente. Migrate fica num lugar so: o entrypoint.
+            # NAO rodar migrate aqui. O proprio boot do container ja migra
+            # (src/start_service.sh roda manage.py migrate --noinput antes de
+            # subir o servidor). Migrate fica num lugar so: o entrypoint.
 
-      - name: Smoke test
-        run: |
-          set -e
-          ok=0
-          for i in $(seq 1 15); do
-            if curl -fsS http://localhost/swagger/ >/dev/null; then
-              ok=1; break
-            fi
-            echo "swagger ainda nao respondeu (tentativa $i), aguardando..."
-            sleep 4
-          done
-          if [ "$ok" != "1" ]; then
-            echo "FALHA: /swagger/ nao respondeu 200"
-            exit 1
-          fi
-          echo "OK: /swagger/ 200"
+            # ----- smoke test (proxy interno publica :80 no host da VM) -----
+            # So testa o Service. O Front tem o seu proprio deploy/smoke; um
+            # front quebrado NAO pode reprovar o deploy do Service.
+            ok=0
+            for i in $(seq 1 15); do
+              if curl -fsS http://localhost/swagger/ >/dev/null; then ok=1; break; fi
+              echo "swagger ainda nao respondeu (tentativa $i), aguardando..."
+              sleep 4
+            done
+            [ "$ok" = "1" ] || { echo "FALHA: /swagger/ nao respondeu 200"; exit 1; }
+            echo "OK: /swagger/ 200"
 
-          # Rota viva da API: 401 (auth) ou 200 e sucesso; 000/502 e falha.
-          api_code=$(curl -s -o /dev/null -w '%{http_code}' \
-            http://localhost/api/v1/supported-metrics/ || echo 000)
-          echo "API /supported-metrics/ -> $api_code"
-          case "$api_code" in
-            200|401|403) echo "OK: API viva" ;;
-            *) echo "FALHA: API code $api_code"; exit 1 ;;
-          esac
-
-          # Front responde na raiz.
-          if curl -fsS http://localhost/ >/dev/null; then
-            echo "OK: Front 200"
-          else
-            echo "FALHA: Front nao respondeu na raiz"
-            exit 1
-          fi
-
-      - name: Logs em caso de falha
-        if: failure()
-        run: docker compose -f "$COMPOSE_FILE" logs --tail=120
+            api_code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/v1/supported-metrics/ || echo 000)
+            echo "API /supported-metrics/ -> $api_code"
+            case "$api_code" in
+              200|401|403) echo "OK: API viva" ;;
+              *) echo "FALHA: API code $api_code"; exit 1 ;;
+            esac
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## O que muda

Migra o deploy de produção do **self-hosted runner** (instalado dentro da VM) para **SSH a partir de um runner cloud** (`ubuntu-latest`). Motivo: a VM do LAPPIS vai ser isolada da rede do Lab; a saída pra internet continua (alcança DockerHub) e a entrada passa a ser só pela porta de firewall (SSH).

Também torna o deploy **independente por repo**: hoje o deploy só existe aqui no Service e só dispara em push pro develop, então **um merge no Front nunca atualizava o front em produção** (só quando alguém mexia no back). O Front ganha o seu próprio deploy em PR separado.

### Detalhes
- Dispara via `workflow_run` **depois** do `Publish Docker Image`: nunca dá pull antes da imagem nova existir no DockerHub (corrige a race do `push:develop` simultâneo build+deploy).
- compose/nginx vão pra box via `scp`; os env-vars seguem provisionados na VM (fora do repo).
- `flock` na box serializa com o deploy do Front (mutex cross-repo, que o `concurrency` do Actions não cobre).
- Smoke testa **só o Service** (`/swagger/` + API); front quebrado não reprova mais o deploy do Service.
- actions de terceiro pinadas por SHA; `fingerprint` do host key opcional via secret.

## ⚠️ Antes de mergear (setup único, fora do CI)
O deploy precisa destes **secrets** nos dois repos: `SSH_HOST`, `SSH_PORT`, `SSH_USER`, `SSH_KEY` (chave de deploy dedicada) e opcional `SSH_KNOWN_HOST_FP`. E a box precisa de `~/msgram-deploy` com o compose + `env-vars`. Tudo isso é provisionado por um script de setup rodado uma vez. **Mergear antes disso faz o primeiro deploy falhar.**

Revisado adversarialmente (infra) antes de subir.