### PR TITLE
ci: deploy de prod via runner self-hosted (corrige SSH cloud inalcancavel)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,20 +1,19 @@
-name: Deploy Prod (SSH)
+name: Deploy Prod (self-hosted)
 
-# Deploy de producao na VM do LAPPIS via SSH, a partir de um runner cloud
-# (ubuntu-latest). Antes rodava num self-hosted runner instalado DENTRO da VM;
-# migramos pra SSH porque a VM vai ser isolada da rede do Lab e o unico acesso
-# de entrada passa a ser a porta de firewall (redirect). Saida pra internet
-# continua, entao o runner cloud alcanca o DockerHub e a VM aceita o SSH.
+# Deploy de producao na VM do LAPPIS via runner SELF-HOSTED instalado nela
+# (lappis-54). A VM nao aceita conexao de ENTRADA da nuvem do GitHub (firewall
+# do Lab so libera SSH por IP especifico), entao deploy por SSH a partir de
+# runner cloud nao funciona. O runner self-hosted conecta de DENTRO pra fora
+# (saida 443), o que sobrevive ao isolamento de rede da VM.
 #
 # A box so PUXA imagens buildadas no docker-publish.yml, nunca builda.
 #
 # Dispara DEPOIS que a imagem do Service e publicada (workflow_run sobre o
 # "Publish Docker Image"), pra nunca dar pull antes da imagem nova existir no
-# DockerHub. Deploy do Service e independente do Front: mexer aqui so redeploya
-# o Service (e atualiza compose/nginx); o Front tem o seu proprio deploy.
+# DockerHub. Independente do Front: mexer aqui so redeploya o Service (e
+# atualiza compose/nginx). O Front tem o seu proprio deploy + runner.
 #
-# OBS workflow_run: so dispara quando este arquivo ja esta no branch DEFAULT
-# (develop, confirmado). O proprio merge pra develop ja deixa o arquivo la.
+# OBS workflow_run: so dispara com este arquivo ja no branch DEFAULT (develop).
 
 on:
   workflow_run:
@@ -31,82 +30,70 @@ concurrency:
 
 jobs:
   deploy:
-    name: Pull + up + smoke (SSH)
-    runs-on: ubuntu-latest
-    # workflow_dispatch nao tem conclusion; via workflow_run so segue se o
-    # build/publish passou (PR recusado ou build quebrado nao deploya).
+    name: Pull + up + smoke
+    runs-on: [self-hosted, msgram-prod]
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
+    env:
+      DEPLOY_DIR: /home/lappis/msgram-deploy
+
     steps:
-      - name: Checkout (compose + nginx)
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # O compose e o nginx vivem neste repo e sao a fonte da verdade da
-      # orquestracao. Subimos a versao fresca pra box a cada deploy do Service.
-      # strip_components: 1 tira o prefixo "deploy/" -> arquivos caem direto em
-      # ~/msgram-deploy/ (docker-compose.prod.yml, nginx/default.conf).
-      # Os env-vars (.service.env / .postgres.env) NAO vem do repo: vivem
-      # provisionados na box em ~/msgram-deploy/env-vars (gitignored, fora do
-      # checkout), configurados uma vez no setup da VM.
-      - name: Enviar compose/nginx pra VM
-        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
+      # ~/msgram-deploy e o diretorio canonico de deploy na box (compartilhado
+      # com o deploy do Front). Os env-vars vivem em ~/msgram-deploy/env-vars
+      # (symlink pra /home/lappis/msgram-env, provisionado fora do repo). Aqui
+      # so atualizamos compose + nginx com a versao fresca deste repo.
+      - name: Atualizar compose/nginx na box
+        run: |
+          mkdir -p "$DEPLOY_DIR/nginx"
+          cp deploy/docker-compose.prod.yml "$DEPLOY_DIR/docker-compose.prod.yml"
+          cp deploy/nginx/default.conf "$DEPLOY_DIR/nginx/default.conf"
+
+      - name: Login no DockerHub
+        uses: docker/login-action@v3
         with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          fingerprint: ${{ secrets.SSH_KNOWN_HOST_FP }}
-          source: "deploy/docker-compose.prod.yml,deploy/nginx/default.conf"
-          target: "~/msgram-deploy"
-          strip_components: 1
-          overwrite: true
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Deploy (login + pull + up + smoke)
-        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          fingerprint: ${{ secrets.SSH_KNOWN_HOST_FP }}
-          command_timeout: 15m
-          envs: DOCKERHUB_USERNAME,DOCKERHUB_TOKEN
-          script: |
-            set -e
-            cd ~/msgram-deploy
-            export DOCKERHUB_USERNAME="$DOCKERHUB_USERNAME"
-            echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-
-            # flock serializa deploy do Service e do Front na MESMA box. O
-            # concurrency do Actions e por-repo e nao cria mutex cross-repo;
-            # dois `compose up` simultaneos dao race. O lock fica na box.
-            flock /tmp/msgram-deploy.lock -c '
-              docker compose -f docker-compose.prod.yml pull
-              docker compose -f docker-compose.prod.yml up -d --remove-orphans
-            '
-
-            # NAO rodar migrate aqui. O proprio boot do container ja migra
-            # (src/start_service.sh roda manage.py migrate --noinput antes de
-            # subir o servidor). Migrate fica num lugar so: o entrypoint.
-
-            # ----- smoke test (proxy interno publica :80 no host da VM) -----
-            # So testa o Service. O Front tem o seu proprio deploy/smoke; um
-            # front quebrado NAO pode reprovar o deploy do Service.
-            ok=0
-            for i in $(seq 1 15); do
-              if curl -fsS http://localhost/swagger/ >/dev/null; then ok=1; break; fi
-              echo "swagger ainda nao respondeu (tentativa $i), aguardando..."
-              sleep 4
-            done
-            [ "$ok" = "1" ] || { echo "FALHA: /swagger/ nao respondeu 200"; exit 1; }
-            echo "OK: /swagger/ 200"
-
-            api_code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/v1/supported-metrics/ || echo 000)
-            echo "API /supported-metrics/ -> $api_code"
-            case "$api_code" in
-              200|401|403) echo "OK: API viva" ;;
-              *) echo "FALHA: API code $api_code"; exit 1 ;;
-            esac
+      - name: Pull + up
+        working-directory: /home/lappis/msgram-deploy
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          # flock serializa com o deploy do Front na MESMA box. O concurrency do
+          # Actions e por-repo e nao cria mutex cross-repo; dois `compose up`
+          # simultaneos dao race. O lock fica na box.
+          flock /tmp/msgram-deploy.lock -c '
+            docker compose -f docker-compose.prod.yml pull
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+          '
+
+      # NAO rodar migrate aqui. O boot do container ja migra (start_service.sh
+      # roda manage.py migrate --noinput). Migrate fica num lugar so.
+
+      - name: Smoke test (so Service)
+        run: |
+          set -e
+          # Front quebrado NAO pode reprovar o deploy do Service.
+          ok=0
+          for i in $(seq 1 15); do
+            if curl -fsS http://localhost/swagger/ >/dev/null; then ok=1; break; fi
+            echo "swagger ainda nao respondeu (tentativa $i), aguardando..."
+            sleep 4
+          done
+          [ "$ok" = "1" ] || { echo "FALHA: /swagger/ nao respondeu 200"; exit 1; }
+          echo "OK: /swagger/ 200"
+
+          api_code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/api/v1/supported-metrics/ || echo 000)
+          echo "API /supported-metrics/ -> $api_code"
+          case "$api_code" in
+            200|401|403) echo "OK: API viva" ;;
+            *) echo "FALHA: API code $api_code"; exit 1 ;;
+          esac
+
+      - name: Logs em caso de falha
+        if: failure()
+        working-directory: /home/lappis/msgram-deploy
+        run: docker compose -f docker-compose.prod.yml logs --tail=120


### PR DESCRIPTION
Fix-forward do deploy. O deploy por SSH a partir de runner cloud (mergeado no #34) da `i/o timeout`: o firewall do Lab nao libera entrada da nuvem do GitHub na VM. Volta pro **runner self-hosted** (lappis-54, ja instalado na VM), que conecta de dentro pra fora e sobrevive ao isolamento.

Mantem tudo que importa do #34: dispara via `workflow_run` apos o publish, independente do Front, smoke so do Service, flock cross-repo, `~/msgram-deploy` como dir canonico (env-vars por symlink).

Pareado com o fix do Front.