### PR TITLE
fix(deploy): pina nome do projeto compose em 'deploy' (corrige conflito de container)

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -17,6 +17,14 @@
 # na box, nunca no repo.
 # ============================================================
 
+# Nome FIXO do projeto compose. Sem isso, o project name vira o basename do
+# diretorio onde o compose roda, que mudou entre o deploy antigo (rodava do
+# checkout do runner -> "deploy") e o novo (~/msgram-deploy). Project name
+# diferente = compose cria stack/volume PARALELOS e colide nos container_name
+# fixos (msgram_db etc.). Pinar em "deploy" faz todo deploy (Service e Front)
+# adotar a stack existente e reusar o volume com dados (deploy_service_postgres_data).
+name: deploy
+
 volumes:
   service_postgres_data:
 


### PR DESCRIPTION
O deploy self-hosted falhou com `Conflict. The container name /msgram_db is already in use`. Causa: o project name do compose virava o basename do diretorio, que mudou entre o deploy antigo (rodava do checkout do runner, project=`deploy`) e o novo (`~/msgram-deploy`). Project diferente = stack e volume paralelos + colisao nos `container_name` fixos, e risco de subir um postgres com volume novo (sem dados).

Fix: `name: deploy` no topo do compose. Os dois deploys passam a adotar a stack existente e reusar `deploy_service_postgres_data`.