### PR TITLE
fix(accounts): reconecta signal que salva o token do GitHub no login

### DIFF
--- a/src/accounts/apps.py
+++ b/src/accounts/apps.py
@@ -6,4 +6,8 @@ class AccountsConfig(AppConfig):
     name = "accounts"
 
     def ready(self):
-        pass
+        # Importa os signals para registrar o receiver save_github_token, que
+        # persiste o github_access_token no login social. O import tem efeito
+        # colateral (conecta o receiver); o noqa evita que o lint o remova de
+        # novo, como aconteceu no commit 283ce41.
+        import accounts.signals  # noqa: F401

--- a/src/accounts/tests.py
+++ b/src/accounts/tests.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase
 from parameterized import parameterized
 from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
@@ -555,3 +556,24 @@ class AccountsViews(APITestCaseExpanded):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["valid"])
+
+
+class AccountsAppConfigTest(SimpleTestCase):
+    def test_ready_imports_signals(self):
+        # Regressao 283ce41 ("fix: lint erros"): o ready() de AccountsConfig
+        # trocou "import accounts.signals" por "pass", desconectando o receiver
+        # save_github_token. Sem ele nenhum login persiste o github_access_token
+        # e /accounts/github-organizations/ passa a responder 400. O ready()
+        # precisa importar o modulo de signals pra registrar o receiver.
+        import sys
+
+        from django.apps import apps
+
+        sys.modules.pop("accounts.signals", None)
+        apps.get_app_config("accounts").ready()
+
+        self.assertIn(
+            "accounts.signals",
+            sys.modules,
+            "AccountsConfig.ready() deve importar accounts.signals",
+        )


### PR DESCRIPTION
## Problema

Depois de logar via GitHub, a página /products chama GET /api/v1/accounts/github-organizations/ e recebe 400 "GitHub account not linked or access token missing". O login funciona (usuário autentica e é criado), mas o github_access_token do usuário fica vazio, então qualquer endpoint que precisa da API do GitHub falha.

## Causa

O receiver save_github_token (accounts/signals.py) é quem salva o github_access_token quando a conta social é adicionada ou atualizada. Para o Django registrar esse receiver, o módulo accounts.signals precisa ser importado no ready() da AppConfig. O commit 283ce41 trocou o import de accounts.signals por "pass" no ready(), provavelmente porque o linter marcou o import como não usado. Sem o import, o signal nunca é registrado e o token nunca é salvo no login.

## Correção

Restaura o import de accounts.signals no ready() de AccountsConfig, com "# noqa: F401" para o lint não remover de novo.

## Testes (TDD)

- RED: teste novo em AccountsAppConfigTest que verifica que o ready() importa accounts.signals. Falha com o ready() vazio.
- GREEN: com o import restaurado, o teste passa. Suite de accounts inteira segue verde.
