### PR TITLE
docs(readme): setup do GitHub OAuth App em dev + target make env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 COMPOSE = docker compose
 
-.PHONY: help setup dev seed up down restart build rebuild logs ps clear \
+.PHONY: help env setup dev seed up down restart build rebuild logs ps clear \
         migrate migrations shell superuser \
         test test-smoke test-cov lint format migrations-check check \
         bash
 
 help:
 	@echo "Targets disponiveis:"
+	@echo "  env          - copia env-vars-example -> env-vars (nao sobrescreve)"
 	@echo "  setup        - do zero a stack de pe: env-vars + build + up + espera health"
 	@echo "  dev          - sobe a stack com hot-reload (docker compose up --watch)"
 	@echo "  seed         - popula dados (load_initial_data + seed_grafana)"
@@ -32,6 +33,12 @@ help:
 	@echo "  clear        - down -v --remove-orphans (apaga volumes)"
 
 # --- Onboarding -------------------------------------------------------------
+
+# Copia os templates de ambiente. Idempotente: nao sobrescreve env-vars ja
+# ajustados (as credenciais reais ficam so em env-vars/, que e gitignored).
+env:
+	@test -d env-vars || cp -R env-vars-example env-vars
+	@echo ">>> env-vars pronto (ajuste GITHUB_CLIENT_ID/SECRET pro login GitHub; ver README)."
 
 # Do zero a stack de pe num comando: copia os env-vars (se ainda nao existirem),
 # builda as imagens, sobe e espera o container service ficar healthy (usa o

--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Edite os valores que precisar (em desenvolvimento, os defaults do `env-vars-exam
 
 > **Nota:** em semestres anteriores o `docker-compose` lia `env-vars-example/` diretamente. A partir desta release a separação `example/` × `env-vars/` é obrigatória — o caminho `./env-vars/.postgres.env` está fixado em `docker-compose.yml`.
 
+> Atalho: `make env` faz o `cp -R env-vars-example env-vars` (e `make setup` já copia antes de subir). Mantemos a pasta `env-vars/` em vez de um único `.env` na raiz porque os caminhos `./env-vars/.service.env` e `./env-vars/.postgres.env` estão fixados no `docker-compose.yml`.
+
+### 1.1. Configurar o GitHub OAuth App (login com GitHub em dev)
+
+Os defaults de `GITHUB_CLIENT_ID` / `GITHUB_SECRET` no `env-vars-example/.service.env` são placeholders (`CL13NT1D` / `S3CR3T`): a API sobe, mas o **login real com GitHub** só funciona com um OAuth App próprio. Para habilitá-lo em desenvolvimento:
+
+1. Acesse **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App** (<https://github.com/settings/developers>).
+2. Preencha:
+   - **Application name**: livre (ex: `MeasureSoftGram (dev)`).
+   - **Homepage URL**: `http://127.0.0.1:3000`
+   - **Authorization callback URL**: `http://127.0.0.1:3000` — precisa **bater com o `LOGIN_REDIRECT_URL`**. O backend usa esse valor como `callback_url` na troca do `code` (`src/accounts/views.py`); em dev o callback é o próprio frontend, que recebe o `?code=` do GitHub e o repassa ao backend.
+3. Clique em **Register application** e gere um **client secret**.
+4. Cole os valores em `env-vars/.service.env`:
+
+   ```env
+   GITHUB_CLIENT_ID=<client id do OAuth App>
+   GITHUB_SECRET=<client secret gerado>
+   LOGIN_REDIRECT_URL=http://127.0.0.1:3000
+   ```
+
+5. Suba ou reinicie o service (`make up` / `docker compose up`).
+
+Os **scopes** (`read:user`, `user:email`, `read:project`, `read:org`, `repo`) já estão definidos no backend (`SOCIALACCOUNT_PROVIDERS` em `config/settings/base.py`); não precisam ser configurados no OAuth App.
+
+> **Produção:** use um OAuth App separado, com a *Authorization callback URL* apontando pro domínio real (ex: `http://msgram.lappis.rocks`) e as credenciais no `env-vars/.service.env` do servidor. Os placeholders de PROD estão comentados no `env-vars-example/.service.env`.
+
 ### 2. Suba os containers
 
 ```bash


### PR DESCRIPTION
## Descricao

Documenta no README como habilitar o login com GitHub em desenvolvimento (os placeholders `CL13NT1D`/`S3CR3T` do `env-vars-example` fazem a API subir, mas nao o OAuth real) e adiciona um atalho `make env`.

## Mudancas

- **README - secao "Configurar o GitHub OAuth App"**: passo a passo pra criar o OAuth App, com a *Authorization callback URL* batendo em `LOGIN_REDIRECT_URL` (o backend usa esse valor como `callback_url` na troca do `code`, `src/accounts/views.py`; em dev o callback e o proprio frontend, que recebe o `?code=` e repassa ao backend). Lista as env vars a preencher e nota que os scopes ja vem do backend (`SOCIALACCOUNT_PROVIDERS`).
- **`make env`**: `cp -R env-vars-example env-vars` idempotente.
- **Decisao documentada**: mantida a pasta `env-vars/` em vez de um `.env` na raiz, porque os caminhos `./env-vars/.service.env` e `.postgres.env` estao fixados no `docker-compose.yml` (um `.env` na raiz nao seria carregado e enganaria).

## Validacao

- `make env` e `make help` OK; `make lint` verde.

Closes #44