### PR TITLE
fix(organizations): Product.save nao duplica a Default pre-config (#14)

### DIFF
--- a/src/organizations/models.py
+++ b/src/organizations/models.py
@@ -82,8 +82,8 @@ class Product(models.Model):
 
         ReleaseConfiguration.objects.get_or_create(
             name="Default pre-config",
-            data=staticfiles.DEFAULT_PRE_CONFIG,
             product=self,
+            defaults={"data": staticfiles.DEFAULT_PRE_CONFIG},
         )
 
 

--- a/src/organizations/tests/test_products_models.py
+++ b/src/organizations/tests/test_products_models.py
@@ -1,0 +1,39 @@
+import copy
+from unittest.mock import patch
+
+from release_configuration.models import ReleaseConfiguration
+from utils import staticfiles
+from utils.tests import APITestCaseExpanded
+
+
+class ProductSaveReleaseConfigurationCase(APITestCaseExpanded):
+    """
+    Garante que salvar um Product novamente nao duplica a
+    pre-configuracao "Default pre-config", mesmo quando o
+    DEFAULT_PRE_CONFIG do msgram-core muda entre versoes.
+    """
+
+    def get_default_release_configs(self, product):
+        return ReleaseConfiguration.objects.filter(
+            name="Default pre-config",
+            product=product,
+        )
+
+    def test_product_save_does_not_duplicate_default_pre_config(self):
+        org = self.get_organization()
+        product = self.get_product(org)
+
+        self.assertEqual(self.get_default_release_configs(product).count(), 1)
+
+        # Simula a mudanca do DEFAULT_PRE_CONFIG entre versoes do core:
+        # o payload muda, mas continua valido.
+        changed_pre_config = copy.deepcopy(staticfiles.DEFAULT_PRE_CONFIG)
+        changed_pre_config["version"] = "next"
+
+        with patch.object(
+            staticfiles, "DEFAULT_PRE_CONFIG", changed_pre_config
+        ):
+            product.name = "Renamed Product"
+            product.save()
+
+        self.assertEqual(self.get_default_release_configs(product).count(), 1)


### PR DESCRIPTION
## Descricao

`Product.save()` usava `get_or_create` com `data=DEFAULT_PRE_CONFIG` no lookup. Como `get_or_create` usa todos os kwargs como filtro, se o `DEFAULT_PRE_CONFIG` do msgram-core mudar entre versoes, um `save()` posterior (save roda em qualquer update) nao encontra match e cria uma **segunda** `ReleaseConfiguration` 'Default pre-config'. Produto acaba com multiplas pre-configs default.

## Correcao

Move `data` do lookup para `defaults`, deixando so `name` e `product` no lookup. Produtos existentes mantem a primeira pre-config mesmo se o DEFAULT mudar.

## TDD (RED + GREEN)

- **RED** (`test(organizations): ... (RED)`): novo `test_products_models.py` simula a mudanca do DEFAULT via `patch` e espera 1 config default. Falhava com `AssertionError: 2 != 1`.
- **GREEN** (`fix(organizations): ... (GREEN)`): o fix no `get_or_create`. Teste passa.

## Validacao

- Suite `organizations/`: **85 passed**. flake8 `src/organizations/`: 0.
- Sem migrations (so logica em save()). Guarda de imutabilidade do ReleaseConfiguration inalterada (get_or_create nao chama save() quando a config ja existe).

Closes #14