### PR TITLE
fix(goals): validar Goal.data e bloquear save invalido (#11)

### DIFF
--- a/src/goals/models.py
+++ b/src/goals/models.py
@@ -1,5 +1,6 @@
 from typing import Dict, Iterable
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 
@@ -26,14 +27,23 @@ class Goal(models.Model):
     )
 
     @staticmethod
-    def validate_goal(goal_dict: Dict[str, int]):
+    def validate_goal(goal_dict: Dict[str, int]) -> bool:
+        if not isinstance(goal_dict, dict) or not goal_dict:
+            return False
+
+        for value in goal_dict.values():
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return False
+
         return True
 
     def save(self, *args, **kwargs):
         if self.id:
             raise ValueError("It's not allowed to update a goal")
 
-        self.validate_goal(self.data)
+        if not self.validate_goal(self.data):
+            raise ValidationError("The goal data is invalid")
+
         return super().save(*args, **kwargs)
 
 

--- a/src/goals/tests/test_goal_models.py
+++ b/src/goals/tests/test_goal_models.py
@@ -1,0 +1,64 @@
+from datetime import date
+
+from django.core.exceptions import ValidationError
+
+from goals.models import Goal
+from utils.tests import APITestCaseExpanded
+
+
+class GoalModelTestCase(APITestCaseExpanded):
+    def setUp(self):
+        self.user = self.get_or_create_test_user()
+        self.org = self.get_organization(add_user=False)
+        self.product = self.get_product(self.org)
+
+    def create_goal(self, data):
+        return Goal.objects.create(
+            created_at=date.today(),
+            created_by=self.user,
+            product=self.product,
+            data=data,
+        )
+
+    def test_validate_goal_returns_true_for_valid_numeric_dict(self):
+        self.assertTrue(Goal.validate_goal({"reliability": 53}))
+        self.assertTrue(
+            Goal.validate_goal({"reliability": 53, "maintainability": 12.5})
+        )
+
+    def test_validate_goal_returns_false_for_non_dict(self):
+        self.assertFalse(Goal.validate_goal([]))
+        self.assertFalse(Goal.validate_goal(None))
+        self.assertFalse(Goal.validate_goal("reliability"))
+
+    def test_validate_goal_returns_false_for_empty_dict(self):
+        self.assertFalse(Goal.validate_goal({}))
+
+    def test_validate_goal_returns_false_for_non_numeric_value(self):
+        self.assertFalse(Goal.validate_goal({"reliability": "alta"}))
+
+    def test_validate_goal_returns_false_for_boolean_value(self):
+        self.assertFalse(Goal.validate_goal({"reliability": True}))
+
+    def test_save_raises_for_empty_dict(self):
+        with self.assertRaises(ValidationError):
+            self.create_goal({})
+
+    def test_save_raises_for_list_data(self):
+        with self.assertRaises(ValidationError):
+            self.create_goal([])
+
+    def test_save_raises_for_non_numeric_value(self):
+        with self.assertRaises(ValidationError):
+            self.create_goal({"reliability": "alta"})
+
+    def test_save_persists_valid_goal(self):
+        goal = self.create_goal(
+            {
+                "reliability": 53,
+                "maintainability": 53,
+                "functional_suitability": 53,
+            }
+        )
+        self.assertIsNotNone(goal.id)
+        self.assertEqual(Goal.objects.filter(id=goal.id).count(), 1)


### PR DESCRIPTION
## Descricao

`Goal.validate_goal` era um stub que retornava `True` sempre, e `Goal.save()` o chamava mas **ignorava o retorno** - dado invalido em `Goal.data` (JSONField) persistia silenciosamente, e a validacao ficava latente (mesmo que alguem a implementasse retornando False, o save nao bloqueava).

## Correcao

- `validate_goal(goal_dict) -> bool`: reprova (`False`) se `data` nao for um dict, for dict vazio, ou tiver qualquer valor nao-numerico (`bool` tratado como invalido). Validacao minima de shape, sem impor faixa 0-100 pra nao arriscar quebrar goals reais.
- `save()`: passa a **verificar o retorno** e levantar `ValidationError` em vez de persistir. Guarda de imutabilidade (save em registro existente -> `ValueError`) intacta e antes da validacao.

Seguro: o fluxo real de criacao (serializer + Equalizer) sempre produz dict numerico valido, entao creates legitimos nao disparam o raise; so entradas genuinamente invalidas passam a ser bloqueadas.

## TDD (RED + GREEN)

- **RED** (`test(goals): ... (RED)`): novo `test_goal_models.py` (9 testes) cobre os ramos de `validate_goal` e o `save()`. Rodando so o teste antes do fix: **7 failed, 2 passed**.
- **GREEN** (`fix(goals): ... (GREEN)`): o fix. Suite `goals/` completa: **20 passed** (11 endpoints existentes + 9 novos).

## Validacao

- `pytest goals`: 20 passed. flake8 `src/goals/`: 0. Sem migrations (so logica de model).

Closes #11