### PR TITLE
fix(release_configuration): imutabilidade via ImmutableQuerySet (#12)

### DIFF
--- a/src/release_configuration/models.py
+++ b/src/release_configuration/models.py
@@ -8,6 +8,29 @@ from subcharacteristics.models import SupportedSubCharacteristic
 from utils.exceptions import InvalidReleaseConfigurationException
 
 
+class ImmutableQuerySet(models.QuerySet):
+    """
+    QuerySet que garante a imutabilidade de ReleaseConfiguration mesmo pelos
+    vetores que contornam o `save()` customizado do model.
+
+    `QuerySet.update()` e `QuerySet.bulk_update()` vão direto ao SQL, não
+    instanciam o model nem chamam `save()`, então bypassavam a guarda de
+    imutabilidade. Aqui ambos levantam `ValueError` com a mesma semântica do
+    `save()`. `delete()` NÃO é bloqueado: o Product tem on_delete=CASCADE para
+    release_configuration e deletes em cascata são legítimos.
+    """
+
+    def update(self, *args, **kwargs):
+        raise ValueError(
+            "It's not allowed to edit a release-configuration"
+        )
+
+    def bulk_update(self, *args, **kwargs):
+        raise ValueError(
+            "It's not allowed to edit a release-configuration"
+        )
+
+
 class ReleaseConfiguration(models.Model):
     """
     Classe que abstrai uma pré-configuração do modelo.
@@ -22,6 +45,8 @@ class ReleaseConfiguration(models.Model):
         # querysets os registros mais recentes vem
         # primeiro (qs.first() == mais recente)
         ordering = ["-created_at"]
+
+    objects = ImmutableQuerySet.as_manager()
 
     created_at = models.DateTimeField(default=timezone.now)
     name = models.CharField(max_length=128, null=True, blank=True)

--- a/src/release_configuration/tests.py
+++ b/src/release_configuration/tests.py
@@ -104,3 +104,32 @@ class TestConfigEnpoints(APITestCaseExpanded):
         )
         self.assertEqual(configs_resp.status_code, status.HTTP_200_OK)
         self.assertTrue(configs_resp.json()["created_config"])
+
+
+class TestReleaseConfigurationImmutability(APITestCaseExpanded):
+    def setUp(self):
+        self.user = self.get_or_create_test_user()
+        self.org = self.get_organization()
+        self.prod = self.get_product(self.org)
+        # Product.save() cria automaticamente uma release-config default
+        self.config = self.prod.release_configuration.first()
+
+    def test_that_queryset_update_is_prohibited(self):
+        self.assertIsNotNone(self.config)
+        with self.assertRaises(ValueError):
+            ReleaseConfiguration.objects.filter(pk=self.config.pk).update(
+                data={"hacked": True}
+            )
+
+    def test_that_reverse_manager_update_is_prohibited(self):
+        with self.assertRaises(ValueError):
+            self.prod.release_configuration.filter(
+                pk=self.config.pk
+            ).update(data={"hacked": True})
+
+    def test_that_bulk_update_is_prohibited(self):
+        self.config.data = {"hacked": True}
+        with self.assertRaises(ValueError):
+            ReleaseConfiguration.objects.bulk_update(
+                [self.config], ["data"]
+            )


### PR DESCRIPTION
## Descricao

A imutabilidade de `ReleaseConfiguration` (guarda no `save()` que levanta `ValueError` ao editar registro existente) so valia via ORM `.save()`. `ReleaseConfiguration.objects.filter(...).update(...)` / `.update(...)` / `bulk_update(...)` vao direto ao SQL, nao instanciam o model nem chamam `save()`, e bypassavam a guarda. Sem constraint a nivel de banco.

## Correcao

`ImmutableQuerySet` como manager default: `update()` e `bulk_update()` levantam `ValueError` com a mesma semantica do `save()`. Vale tambem para o reverse manager `product.release_configuration`. `delete()` **nao** e bloqueado (necessario pelo `on_delete=CASCADE` do `Product`). Verificado: nenhum codigo do projeto usa `ReleaseConfiguration.objects.update()`, entao o fix nao quebra nada legitimo (`get_or_create` em `Product.save()` usa create, intacto).

## TDD (RED + GREEN)

- **RED**: nova `TestReleaseConfigurationImmutability` (3 testes: update via manager, via reverse manager, bulk_update). Falhava com `ValueError not raised`.
- **GREEN**: `ImmutableQuerySet`. Testes passam.

## Validacao

- `pytest release_configuration organizations`: **90 passed**. flake8: 0. Sem migration (camada ORM).

Closes #12