### PR TITLE
fix(goals): imutabilidade de Goal via ImmutableQuerySet (#13)

### DIFF
--- a/src/goals/models.py
+++ b/src/goals/models.py
@@ -5,6 +5,25 @@ from django.db import models
 from django.utils import timezone
 
 
+class ImmutableQuerySet(models.QuerySet):
+    """
+    QuerySet que garante a imutabilidade de Goal mesmo pelos vetores que
+    contornam o `save()` customizado do model.
+
+    `QuerySet.update()` e `QuerySet.bulk_update()` vão direto ao SQL, não
+    instanciam o model nem chamam `save()`, então bypassavam a guarda de
+    imutabilidade. Aqui ambos levantam `ValueError` com a mesma semântica do
+    `save()`. `delete()` NÃO é bloqueado: o Product tem on_delete=CASCADE para
+    goals e deletes em cascata são legítimos.
+    """
+
+    def update(self, *args, **kwargs):
+        raise ValueError("It's not allowed to update a goal")
+
+    def bulk_update(self, *args, **kwargs):
+        raise ValueError("It's not allowed to update a goal")
+
+
 class Goal(models.Model):
     """
     Tabela que armazena os objetivos de qualidade
@@ -13,6 +32,8 @@ class Goal(models.Model):
 
     class Meta:
         ordering = ("-created_at",)
+
+    objects = ImmutableQuerySet.as_manager()
 
     created_at = models.DateTimeField(default=timezone.now)
     data = models.JSONField()

--- a/src/goals/tests/test_goal_models.py
+++ b/src/goals/tests/test_goal_models.py
@@ -62,3 +62,42 @@ class GoalModelTestCase(APITestCaseExpanded):
         )
         self.assertIsNotNone(goal.id)
         self.assertEqual(Goal.objects.filter(id=goal.id).count(), 1)
+
+
+class GoalImmutabilityTestCase(APITestCaseExpanded):
+    def setUp(self):
+        self.user = self.get_or_create_test_user()
+        self.org = self.get_organization(add_user=False)
+        self.product = self.get_product(self.org)
+
+    def create_goal(self, data):
+        return Goal.objects.create(
+            created_at=date.today(),
+            created_by=self.user,
+            product=self.product,
+            data=data,
+        )
+
+    def test_queryset_update_raises(self):
+        goal = self.create_goal({"reliability": 53})
+        with self.assertRaises(ValueError):
+            Goal.objects.filter(pk=goal.pk).update(data={"reliability": 99})
+
+    def test_reverse_manager_update_raises(self):
+        goal = self.create_goal({"reliability": 53})
+        with self.assertRaises(ValueError):
+            self.product.goals.filter(pk=goal.pk).update(
+                data={"reliability": 99}
+            )
+
+    def test_bulk_update_raises(self):
+        goal = self.create_goal({"reliability": 53})
+        goal.data = {"reliability": 99}
+        with self.assertRaises(ValueError):
+            Goal.objects.bulk_update([goal], ["data"])
+
+    def test_reads_still_work(self):
+        goal = self.create_goal({"reliability": 53})
+        self.assertEqual(Goal.objects.filter(pk=goal.pk).first(), goal)
+        self.assertEqual(Goal.objects.all().count(), 1)
+        self.assertEqual(self.product.goals.count(), 1)


### PR DESCRIPTION
## Descricao

Gemeo da #12, para `Goal`. A imutabilidade (guarda no `save()` que levanta `ValueError` ao editar) so valia via ORM `.save()`. `Goal.objects.filter(...).update(...)` / `bulk_update(...)` iam direto ao SQL e bypassavam a guarda. Sem constraint no banco.

## Correcao

`ImmutableQuerySet` como manager default do Goal: `update()`/`bulk_update()` levantam `ValueError("It's not allowed to update a goal")` (mesma mensagem do `save()` do Goal). Vale tambem para o reverse manager `product.goals`. `delete()` **nao** e bloqueado (`on_delete=CASCADE` do Product). Verificado: nenhum codigo usa `Goal.objects.update()`, e o app so expoe CreateModelMixin - fix nao quebra nada.

## TDD (RED + GREEN)

- **RED**: nova `GoalImmutabilityTestCase` (4 testes: update via manager, reverse manager, bulk_update, e guarda de leitura). Os 3 de escrita falhavam com `ValueError not raised`.
- **GREEN**: `ImmutableQuerySet`. Passa.

## Validacao

- `pytest goals`: **24 passed**. flake8: 0. Sem migration.

Closes #13