### PR TITLE
fix(releases): timezone explicita no cron do scheduler (#15)

### DIFF
--- a/src/releases/jobs.py
+++ b/src/releases/jobs.py
@@ -4,6 +4,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from django_apscheduler.jobstores import DjangoJobStore, register_events
+from django.conf import settings
 from django.db import connection
 from django.utils import timezone
 
@@ -148,6 +149,29 @@ def acquire_scheduler_lock():
         return True
 
 
+def build_release_cron_trigger():
+    """Cria o CronTrigger da meia-noite com timezone explicita.
+
+    Usa settings.TIME_ZONE (America/Sao_Paulo) em vez da tz do OS do
+    container, para o gatilho do cron bater com a janela do dia que
+    get_releases_and_create_results computa via timezone.now() do Django.
+    """
+    return CronTrigger(
+        hour=0,
+        minute=0,
+        timezone=settings.TIME_ZONE,
+    )
+
+
+def build_release_scheduler():
+    """Cria o BackgroundScheduler com timezone explicita (settings.TIME_ZONE).
+
+    Evita depender da tz do OS do container, mantendo o scheduler alinhado
+    com o CronTrigger e com a janela de dados do job.
+    """
+    return BackgroundScheduler(timezone=settings.TIME_ZONE)
+
+
 def check_the_need_to_calculate_releases():
     if not acquire_scheduler_lock():
         print(
@@ -156,15 +180,12 @@ def check_the_need_to_calculate_releases():
         )
         return
 
-    scheduler = BackgroundScheduler()
+    scheduler = build_release_scheduler()
     scheduler.add_jobstore(DjangoJobStore(), "default")
 
     scheduler.add_job(
         get_releases_and_create_results,
-        trigger=CronTrigger(
-            hour=00,
-            minute=00,
-        ),
+        trigger=build_release_cron_trigger(),
         name="get_releases_and_create_results",
         jobstore="default",
         replace_existing=True,

--- a/src/releases/tests/test_jobs.py
+++ b/src/releases/tests/test_jobs.py
@@ -1,0 +1,31 @@
+"""
+Testa a timezone explicita do cron do scheduler de releases.
+
+Sem timezone explicita, BackgroundScheduler e CronTrigger usam a tz do OS
+do container. Em container UTC a "meia-noite" dispara 00:00 UTC; em
+container America/Sao_Paulo dispara 00:00 BRT. A janela de dados do job
+(get_releases_and_create_results) e computada com timezone.now() do Django,
+que respeita settings.TIME_ZONE. Gatilho e janela precisam ficar alinhados:
+o trigger deve usar settings.TIME_ZONE explicitamente.
+"""
+
+from django.conf import settings
+from django.test import TestCase
+
+from releases import jobs
+
+
+class ReleaseCronTriggerTimezoneTestCase(TestCase):
+    def test_build_release_cron_trigger_uses_settings_timezone(self):
+        """O CronTrigger do job deve usar settings.TIME_ZONE explicito."""
+        trigger = jobs.build_release_cron_trigger()
+
+        self.assertEqual(str(trigger.timezone), settings.TIME_ZONE)
+        self.assertEqual(str(trigger.timezone), "America/Sao_Paulo")
+
+    def test_build_release_scheduler_uses_settings_timezone(self):
+        """O BackgroundScheduler do job deve usar settings.TIME_ZONE."""
+        scheduler = jobs.build_release_scheduler()
+
+        self.assertEqual(str(scheduler.timezone), settings.TIME_ZONE)
+        self.assertEqual(str(scheduler.timezone), "America/Sao_Paulo")


### PR DESCRIPTION
## Descricao

`check_the_need_to_calculate_releases()` criava `BackgroundScheduler()` e `CronTrigger(hour=0, minute=0)` **sem timezone**, entao a "meia-noite" era interpretada na tz do OS do container (00:00 UTC num container UTC, 00:00 BRT num container America/Sao_Paulo). A MESMA funcao computa a janela do dia com `timezone.now()` do Django (`TIME_ZONE=America/Sao_Paulo`, `USE_TZ=True`), entao gatilho e janela podiam ficar desalinhados.

## Correcao

Helpers `build_release_cron_trigger()` e `build_release_scheduler()` usam `settings.TIME_ZONE` explicitamente (nao hardcode - segue o settings). O disparo do cron fica deterministico e alinhado com a janela `today_min/today_max` do job, independente da tz do OS. Advisory lock e logica de calculo intocados.

## TDD (RED + GREEN)

- **RED**: novo `test_jobs.py` asserta `str(trigger.timezone) == settings.TIME_ZONE == "America/Sao_Paulo"` para trigger e scheduler. tz do OS de teste observada = **UTC**; RED falhou (helpers inexistentes / tz UTC).
- **GREEN**: helpers com `settings.TIME_ZONE`. Passa.

## Validacao

- `pytest releases`: **28 passed** (inclui os 4 de scheduler_lock e endpoints). flake8 `src/releases/`: 0. Sem migration.

## Nota operacional

Em container que ja rodava com `TZ=America/Sao_Paulo` o horario efetivo nao muda; em container UTC o disparo passa de 00:00 UTC para 00:00 BRT (03:00 UTC), que era o alinhamento pretendido.

Closes #15