### PR TITLE
fix(seed-grafana): garante amostra recente para painel Planejado vs R…

### DIFF
--- a/src/organizations/management/commands/seed_grafana.py
+++ b/src/organizations/management/commands/seed_grafana.py
@@ -235,12 +235,16 @@ class Command(BaseCommand):
         all_timestamps = _make_timestamps(self.days, self.end_date)
 
         # IMPORTANTE: Para o pulso ECG funcionar, características e TSQMI devem estar nas MESMAS datas
-        # Seleciona 10 timestamps espaçados uniformemente para TSQMI e características
+        # Seleciona 10 timestamps espaçados uniformemente (incluindo o mais recente) para
+        # TSQMI e características — o painel "Planejado vs Realizado" só considera os
+        # últimos 7 dias, então a última amostra precisa ficar perto de `self.end_date`.
         TSQMI_MEASUREMENTS = 10
-        step = max(1, len(all_timestamps) // TSQMI_MEASUREMENTS)
-        tsqmi_timestamps = [
-            all_timestamps[i * step] for i in range(TSQMI_MEASUREMENTS)
+        last_idx = len(all_timestamps) - 1
+        indices = [
+            round(i * last_idx / (TSQMI_MEASUREMENTS - 1))
+            for i in range(TSQMI_MEASUREMENTS)
         ]
+        tsqmi_timestamps = [all_timestamps[i] for i in indices]
 
         if self.clean_tsqmi:
             TSQMI.objects.filter(repository=repo).delete()


### PR DESCRIPTION
# Fix: seed_grafana não populava dados dentro da janela de 7 dias do painel "Planejado vs Realizado"

## Descrição

Os gráficos da conta de teste estavam quebrando e a visualiualização deles não estava da maneira ideal. Além disso , comando `seed_grafana` amostra 10 datas dentro do período de `--days` para gerar TSQMI e características. O cálculo usava um `step` fixo (`dias // 10`), o que fazia a última data amostrada ficar sempre ~18 dias no passado (com `--days 180`) fora da janela de 7 dias que a query SQL do painel "Planejado vs Realizado" (dashboard `Visão Geral de Qualidade`) usa para buscar a característica mais recente. Resultado: o painel ficava permanentemente vazio em qualquer ambiente que rodasse o seed com os parâmetros padrão, mesmo com o restante do dashboard funcionando.

Não teve issue.

## Porque este Pull Request é necessário?

Sem esse ajuste, qualquer ambiente local/demo que rode `seed_grafana` nunca terá o painel "Planejado vs Realizado" preenchido  o que compromete a demonstração/QA do dashboard "Visão Geral de Qualidade" mesmo quando todos os outros painéis estão corretos.

## Critérios de aceitação
1. [x] A última data amostrada para TSQMI/características fica sempre dentro da janela usada pelo painel (últimos 7 dias), independente do valor de `--days`
2. [x] Comportamento dos demais painéis que dependem das mesmas 10 datas permanece inalterado
3. [x] Validado localmente: `python manage.py seed_grafana --days 180 --clean-all --clean-tsqmi` populando os 9 repositórios de todos os produtos, confirmando via SQL que a query do painel retorna linhas para os 4 produtos (Animalesco, BCE UnB, MeasureSoftGram, Acacia)
