### PR TITLE
fix: resolve problema de dados da conta de teste

### DIFF
--- a/.github/workflows/seed-demo-data.yml
+++ b/.github/workflows/seed-demo-data.yml
@@ -1,0 +1,41 @@
+name: Seed Grafana Demo Data (Prod)
+
+# Popula/atualiza os dados MOCKADOS da conta de demonstracao (msgramteste)
+# direto na producao, via runner self-hosted (unico jeito de rodar comandos
+# na VPS sem acesso SSH direto).
+#
+# Escopo travado nos repositorios de demo conhecidos (REPO_PROFILES em
+# seed_grafana.py) -- --clean-all e --clean-tsqmi filtram por --repos, entao
+# NUNCA tocam em dados reais de outras equipes.
+#
+# Uso: aba Actions -> "Seed Grafana Demo Data (Prod)" -> Run workflow ->
+#   escrever SEED no campo de confirmacao.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Digite SEED para confirmar (recria os dados mockados de demo)'
+        required: true
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: [self-hosted, msgram-prod]
+    steps:
+      - name: Validar confirmação
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "SEED" ]; then
+            echo "Confirmação inválida. Digite exatamente SEED no input pra prosseguir."
+            exit 1
+          fi
+
+      - name: Rodar seed_grafana (escopo travado nos repos de demo)
+        run: |
+          docker exec msgram_service python manage.py seed_grafana \
+            --days 180 --clean-tsqmi --clean-all \
+            --repos "2019.2-Acacia,2019.2-Acacia-Frontend,2020.1-BCE,2021.1_G01_Animalesco_BackEnd,2021.1_G01_Animalesco_FrontEnd,2022-1-MeasureSoftGram-Service,2022-1-MeasureSoftGram-Core,2022-1-MeasureSoftGram-Front,2022-1-MeasureSoftGram-CLI" \
+            --grafana-url http://grafana:3000


### PR DESCRIPTION
# Adiciona workflow manual para popular dados de demonstração em produção

## Descrição
Adiciona um workflow (`seed-demo-data.yml`) disparado manualmente via `workflow_dispatch`, que roda o comando `seed_grafana` direto no runner self-hosted da produção. Isso permite atualizar os dados mockados da conta de demonstração (`msgramteste`).

Sem issue vinculada até o momento.

## Porque este Pull Request é necessário?
Os dados de demonstração dessa conta foram gerados antes de um fix recente no `seed_grafana` (PR #54) e ficaram desatualizados o painel "Planejado vs Realizado" do dashboard "Visão Geral de Qualidade" 

## Critérios de aceitação
1. [x] O workflow só executa mediante confirmação explícita (campo obrigatório com o texto `SEED`)
2. [x] O comando está travado por `--repos` nos 9 repositórios de demo conhecidos, sem risco de apagar dados reais de outras equipes
3. [x] Roda no runner self-hosted (`msgram-prod`), o mesmo usado pelo deploy, sem exigir credenciais adicionais

Closes #numero_da_issue