### PR TITLE
fix(metrics): suporta metricas de runtime e sobe msgram-core para 1.5.4 (#56)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "requests==2.31.0",
     "django-allauth==0.51.0",
     "dj-rest-auth==2.2.5",
-    "msgram-core==1.4.9",
+    "msgram-core==1.5.4",
     "django-extensions==3.2.3",
     "setuptools>=75.0.0,<78",
     "django-debug-toolbar==3.5.0",

--- a/src/math_model/services.py
+++ b/src/math_model/services.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -19,6 +20,8 @@ from subcharacteristics.serializers import \
     CalculatedSubCharacteristicSerializer
 from tsqmi.models import TSQMI
 from tsqmi.serializers import TSQMISerializer
+
+logger = logging.getLogger(__name__)
 
 # Métricas multi-valor (lista de floats por arquivo) — espelha
 # SupportedMetric.get_latest_metric_value em metrics/models.py:46.
@@ -116,6 +119,13 @@ class MathModelServices:
         # com dados de APM. O Service ainda não tem coletor de APM nem noção
         # de comparar releases, então mandá-las aqui só quebraria o cálculo
         # inteiro. Reavaliar quando o coletor existir (issue #56).
+        skipped = set(measure_keys) & set(RUNTIME_MEASURE_KEYS)
+        if skipped:
+            logger.warning(
+                "Runtime measures ignoradas no calculo (sem coletor de APM): %s",
+                ", ".join(sorted(skipped)),
+            )
+
         qs = (
             SupportedMeasure.objects.filter(key__in=measure_keys)
             .exclude(key__in=RUNTIME_MEASURE_KEYS)

--- a/src/math_model/services.py
+++ b/src/math_model/services.py
@@ -8,6 +8,7 @@ from resources import (calculate_characteristics, calculate_measures,
 from characteristics.models import (CalculatedCharacteristic,
                                     SupportedCharacteristic)
 from characteristics.serializers import CalculatedCharacteristicSerializer
+from math_model.utils import RUNTIME_MEASURE_KEYS
 from measures.models import CalculatedMeasure, SupportedMeasure
 from measures.serializers import CalculatedMeasureSerializer
 from metrics.models import CollectedMetric, SupportedMetric
@@ -110,8 +111,15 @@ class MathModelServices:
         """Calcula medidas a partir das métricas em memória."""
         metric_index = self._index_metrics_by_key(collected_metrics)
 
-        qs = SupportedMeasure.objects.filter(key__in=measure_keys).prefetch_related(
-            "metrics"
+        # Runtime measures ficam de fora: o msgram-core 1.5.x as valida com
+        # CompareRunTimeMeasureSchema, que exige o payload de duas releases
+        # com dados de APM. O Service ainda não tem coletor de APM nem noção
+        # de comparar releases, então mandá-las aqui só quebraria o cálculo
+        # inteiro. Reavaliar quando o coletor existir (issue #56).
+        qs = (
+            SupportedMeasure.objects.filter(key__in=measure_keys)
+            .exclude(key__in=RUNTIME_MEASURE_KEYS)
+            .prefetch_related("metrics")
         )
 
         core_params = {"measures": []}

--- a/src/math_model/tests/test_runtime_measures.py
+++ b/src/math_model/tests/test_runtime_measures.py
@@ -1,0 +1,147 @@
+"""
+Testes do recorte das runtime measures no cálculo do modelo matemático.
+
+O msgram-core 1.5.x trouxe medidas de runtime (response_time,
+cpu_utilization, memory_utilization) que são validadas por um schema de
+comparação entre duas releases, alimentado por dados de APM. O Service
+cadastra essas medidas (o core exige que o catálogo esteja completo), mas
+não tem coletor de APM ainda, então elas não podem entrar no
+calculate_measures padrão. Ver issue #56.
+
+Os testes abaixo chamam o msgram-core de verdade: se o filtro sumir, o
+core levanta ValidationError e eles quebram.
+"""
+
+from unittest import mock
+
+from resources import calculate_measures
+
+from math_model import utils
+from math_model.services import MathModelServices
+from math_model.utils import RUNTIME_MEASURE_KEYS
+from measures.models import SupportedMeasure
+from metrics.models import CollectedMetric, SupportedMetric
+from release_configuration.models import ReleaseConfiguration
+from utils import staticfiles
+from utils.tests import APITestCaseExpanded
+
+
+class RuntimeMeasuresAreSkippedTest(APITestCaseExpanded):
+    def setUp(self):
+        self.org = self.get_organization()
+        self.product = self.get_product(self.org)
+        self.repository = self.get_repository(self.product)
+        ReleaseConfiguration.objects.get_or_create(
+            name="Default pre-config",
+            data=staticfiles.DEFAULT_PRE_CONFIG,
+            product=self.product,
+        )
+        self.release_config = self.product.release_configuration.first()
+        self.services = MathModelServices(self.repository, self.product)
+
+    def _collected_metrics(self):
+        """CollectedMetric não persistidos cobrindo as métricas das medidas
+        comuns (as de runtime não têm coletor, por definição)."""
+        metrics = []
+        groups = [
+            (
+                [
+                    "coverage",
+                    "complexity",
+                    "functions",
+                    "comment_lines_density",
+                    "duplicated_lines_density",
+                ],
+                "FIL",
+            ),
+            (["test_execution_time", "tests"], "UTS"),
+            (["test_failures", "test_errors"], "TRK"),
+            (
+                [
+                    "total_issues",
+                    "resolved_issues",
+                    "sum_ci_feedback_times",
+                    "total_builds",
+                ],
+                "TRK",
+            ),
+        ]
+
+        for keys, qualifier in groups:
+            for supported_metric in SupportedMetric.objects.filter(key__in=keys):
+                for value in (0.1, 0.2):
+                    metrics.append(
+                        CollectedMetric(
+                            value=value,
+                            metric=supported_metric,
+                            repository=self.repository,
+                            qualifier=qualifier,
+                        )
+                    )
+
+        return metrics
+
+    def test_runtime_measures_are_registered_in_the_database(self):
+        """Guarda contra teste vazio: se as runtime measures não estivessem
+        cadastradas, o filtro não teria o que filtrar."""
+        registered = set(
+            SupportedMeasure.objects.filter(
+                key__in=RUNTIME_MEASURE_KEYS,
+            ).values_list("key", flat=True)
+        )
+
+        assert RUNTIME_MEASURE_KEYS
+        assert registered == set(RUNTIME_MEASURE_KEYS)
+
+    def test_runtime_measures_are_not_sent_to_the_core(self):
+        """Mesmo pedindo TODAS as medidas cadastradas, o payload que chega
+        ao msgram-core não contém nenhuma runtime measure."""
+        measure_keys = [m.key for m in SupportedMeasure.objects.all()]
+        expected_keys = set(measure_keys) - set(RUNTIME_MEASURE_KEYS)
+
+        assert set(measure_keys) & set(RUNTIME_MEASURE_KEYS)
+
+        # wraps: o core roda de verdade (e ele que rejeitaria uma runtime
+        # measure); o mock existe so pra inspecionar o payload enviado.
+        with mock.patch(
+            "math_model.services.calculate_measures",
+            wraps=calculate_measures,
+        ) as spy:
+            instances, values = self.services.build_calculated_measures(
+                measure_keys,
+                self.release_config,
+                self._collected_metrics(),
+            )
+
+        spy.assert_called_once()
+        core_params = spy.call_args.args[0]
+        sent_keys = {measure["key"] for measure in core_params["measures"]}
+
+        assert sent_keys.isdisjoint(RUNTIME_MEASURE_KEYS)
+        assert sent_keys == expected_keys
+        assert set(values.keys()) == expected_keys
+        assert {i.measure.key for i in instances} == expected_keys
+
+
+class DeriveRuntimeMeasureKeysTest(APITestCaseExpanded):
+    """A lista de runtime measures é derivada do catálogo do msgram-core,
+    não escrita à mão: medida nova que dependa de métrica de observabilidade
+    entra sozinha."""
+
+    def test_matches_the_runtime_measures_of_the_current_core(self):
+        assert set(RUNTIME_MEASURE_KEYS) == {
+            "response_time",
+            "cpu_utilization",
+            "memory_utilization",
+        }
+
+    def test_picks_up_a_new_measure_that_depends_on_a_runtime_metric(self):
+        fake_catalogue = [
+            {"test_coverage": {"metrics": ["coverage"]}},
+            {"future_runtime_measure": {"metrics": ["endpoint_calls", "cpu_usage"]}},
+        ]
+
+        with mock.patch.object(utils, "SUPPORTED_MEASURES", fake_catalogue):
+            derived = utils._derive_runtime_measure_keys()
+
+        assert derived == frozenset({"future_runtime_measure"})

--- a/src/math_model/tests/test_runtime_measures.py
+++ b/src/math_model/tests/test_runtime_measures.py
@@ -129,6 +129,14 @@ class DeriveRuntimeMeasureKeysTest(APITestCaseExpanded):
     entra sozinha."""
 
     def test_matches_the_runtime_measures_of_the_current_core(self):
+        """Tripwire proposital: crava as chaves do core 1.5.x.
+
+        A derivacao acompanha o core sozinha, mas se uma metrica for renomeada
+        la a intersecao vira vazia e o filtro degenera em no-op silencioso.
+        Este teste quebra nesse caso. Falhou depois de subir o core? Confira se
+        RUNTIME_AVAILABLE_METRICS ainda casa com o catalogo dele antes de so
+        atualizar a lista abaixo.
+        """
         assert set(RUNTIME_MEASURE_KEYS) == {
             "response_time",
             "cpu_utilization",

--- a/src/math_model/tests/test_services.py
+++ b/src/math_model/tests/test_services.py
@@ -145,8 +145,10 @@ class MathModelServicesTest(APITestCaseExpanded):
         assert len(instances) == 8
         assert all(isinstance(i, CalculatedMeasure) for i in instances)
         assert all(i.pk is None for i in instances)
-        # Dict tem as mesmas keys, valores são floats
-        assert set(values.keys()) == set(measure_keys)
+        # Dict tem as mesmas keys (menos as runtime measures, que ficam de
+        # fora enquanto não houver coletor de APM), valores são floats
+        expected_keys = set(measure_keys) - set(utils.RUNTIME_MEASURE_KEYS)
+        assert set(values.keys()) == expected_keys
         assert all(isinstance(v, float) for v in values.values())
 
     def test_build_calculated_subcharacteristics_uses_in_memory_values(self):

--- a/src/math_model/utils.py
+++ b/src/math_model/utils.py
@@ -1,3 +1,33 @@
+from staticfiles import SUPPORTED_MEASURES
+
+from utils.staticfiles import RUNTIME_AVAILABLE_METRICS
+
+
+def _derive_runtime_measure_keys():
+    """Deriva do catálogo do msgram-core quais medidas são runtime measures.
+
+    Runtime measure é toda medida suportada que depende de pelo menos uma
+    métrica de observabilidade (RUNTIME_AVAILABLE_METRICS). Derivar em vez de
+    listar na mão faz o Service acompanhar sozinho quando o core adicionar
+    uma medida nova desse tipo.
+    """
+    runtime_metric_keys = {metric["key"] for metric in RUNTIME_AVAILABLE_METRICS}
+
+    keys = set()
+    for measure_data in SUPPORTED_MEASURES:
+        measure_key = next(iter(measure_data))
+        required_metrics = set(measure_data[measure_key]["metrics"])
+        if required_metrics & runtime_metric_keys:
+            keys.add(measure_key)
+
+    return frozenset(keys)
+
+
+# Computado uma vez no import: SUPPORTED_MEASURES e RUNTIME_AVAILABLE_METRICS
+# são estáticos, não faz sentido recalcular a cada cálculo de medida.
+RUNTIME_MEASURE_KEYS = _derive_runtime_measure_keys()
+
+
 def parse_release_configuration(pre_config):
     # Parse configuracao de release para pegar chaves do que foi planejado
     characteristics = []

--- a/src/organizations/management/commands/load_initial_data.py
+++ b/src/organizations/management/commands/load_initial_data.py
@@ -18,6 +18,7 @@ import utils
 from characteristics.models import (CalculatedCharacteristic,
                                     SupportedCharacteristic)
 from goals.serializers import GoalSerializer
+from math_model.utils import RUNTIME_MEASURE_KEYS
 from measures.models import CalculatedMeasure, SupportedMeasure
 from metrics.models import CollectedMetric, SupportedMetric
 from organizations.models import Organization, Product, Repository
@@ -277,7 +278,10 @@ class Command(BaseCommand):
         )
 
     def create_fake_calculated_measures(self, repository):
-        qs = SupportedMeasure.objects.all()
+        # Runtime measures nao entram no fake data: elas nunca sao calculadas
+        # de verdade (ver issue #56), entao inventar historico para elas
+        # produziria serie bonita no dashboard sem contrapartida em producao.
+        qs = SupportedMeasure.objects.exclude(key__in=RUNTIME_MEASURE_KEYS)
         current_entity = [None]
         state = [random.uniform(0.5, 0.85)]
 

--- a/src/organizations/management/commands/load_initial_data.py
+++ b/src/organizations/management/commands/load_initial_data.py
@@ -156,6 +156,7 @@ class Command(BaseCommand):
     def create_supported_metrics(self):
         self.create_sonarqube_supported_metrics()
         self.create_github_supported_metrics()
+        self.create_runtime_supported_metrics()
 
     def create_sonarqube_supported_metrics(self):
         data = staticfiles.SONARQUBE_AVAILABLE_METRICS
@@ -183,6 +184,20 @@ class Command(BaseCommand):
         ]
 
         for metric in github_metrics:
+            with contextlib.suppress(IntegrityError):
+                metric.save()
+
+    def create_runtime_supported_metrics(self):
+        runtime_metrics = [
+            SupportedMetric(
+                key=metric["key"],
+                name=metric["name"],
+                metric_type=metric["metric_type"],
+            )
+            for metric in staticfiles.RUNTIME_AVAILABLE_METRICS
+        ]
+
+        for metric in runtime_metrics:
             with contextlib.suppress(IntegrityError):
                 metric.save()
 

--- a/src/organizations/tests/test_runtime_metrics.py
+++ b/src/organizations/tests/test_runtime_metrics.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from staticfiles import SUPPORTED_MEASURES
+
+from measures.models import SupportedMeasure
+from metrics.models import SupportedMetric
+from organizations.management.commands.load_initial_data import Command
+
+
+def required_metric_keys():
+    """Toda métrica exigida por alguma medida suportada pelo msgram-core."""
+    keys = set()
+    for measure_data in SUPPORTED_MEASURES:
+        measure_key = next(iter(measure_data))
+        keys.update(measure_data[measure_key]["metrics"])
+    return keys
+
+
+class RuntimeMetricsSupportTestCase(TestCase):
+    """
+    O catálogo de métricas do Service precisa cobrir tudo que as medidas do
+    msgram-core exigem. Quando o core ganha medidas novas e o Service não
+    acompanha, create_suported_measures() aborta e derruba a carga inicial
+    inteira, junto de todo teste que depende dela.
+    """
+
+    def setUp(self):
+        self.command = Command()
+
+    def test_every_metric_required_by_a_supported_measure_is_registered(self):
+        self.command.create_supported_metrics()
+
+        registered = set(SupportedMetric.objects.values_list("key", flat=True))
+
+        self.assertEqual(
+            required_metric_keys() - registered,
+            set(),
+            "Há medidas do msgram-core exigindo métricas que o Service não cadastra.",
+        )
+
+    def test_create_supported_measures_registers_every_measure_of_the_core(self):
+        self.command.create_supported_metrics()
+        self.command.create_suported_measures()
+
+        expected = {next(iter(measure)) for measure in SUPPORTED_MEASURES}
+        registered = set(SupportedMeasure.objects.values_list("key", flat=True))
+
+        self.assertEqual(expected - registered, set())

--- a/src/utils/staticfiles/__init__.py
+++ b/src/utils/staticfiles/__init__.py
@@ -2,4 +2,5 @@ from .default_balance_matrix import DEFAULT_BALANCE_MATRIX
 from .default_pre_config import DEFAULT_PRE_CONFIG
 from .github_available_metrics import GITHUB_AVAILABLE_METRICS
 from .mocked_measure_history import MOCKED_MEASURE_HISTORY
+from .runtime_available_metrics import RUNTIME_AVAILABLE_METRICS
 from .sonarqube_available_metrics import SONARQUBE_AVAILABLE_METRICS

--- a/src/utils/staticfiles/runtime_available_metrics.py
+++ b/src/utils/staticfiles/runtime_available_metrics.py
@@ -1,0 +1,28 @@
+# flake8: noqa
+# pylint: skip-file
+# Métricas de execução exigidas pelas runtime measures do msgram-core 1.5.x
+# (response_time, cpu_utilization, memory_utilization). Diferente das demais,
+# não vêm do SonarQube nem da API do GitHub: são dados de observabilidade da
+# aplicação em execução.
+RUNTIME_AVAILABLE_METRICS = [
+    {
+        "key": "endpoint_calls",
+        "metric_type": "INT",
+        "name": "number of calls per endpoint",
+    },
+    {
+        "key": "mean_response_time",
+        "metric_type": "FLOAT",
+        "name": "mean response time per endpoint",
+    },
+    {
+        "key": "cpu_usage",
+        "metric_type": "FLOAT",
+        "name": "cpu usage per endpoint",
+    },
+    {
+        "key": "memory_usage",
+        "metric_type": "FLOAT",
+        "name": "memory usage per endpoint",
+    },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -559,6 +559,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "marshmallow"
 version = "3.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -626,7 +635,7 @@ requires-dist = [
     { name = "drf-nested-routers", specifier = "==0.93.4" },
     { name = "drf-yasg", specifier = "==1.21.7" },
     { name = "gunicorn", specifier = "==20.1.0" },
-    { name = "msgram-core", specifier = "==1.4.9" },
+    { name = "msgram-core", specifier = "==1.5.4" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
     { name = "pytz", specifier = "==2022.1" },
     { name = "requests", specifier = "==2.31.0" },
@@ -649,16 +658,27 @@ dev = [
 
 [[package]]
 name = "msgram-core"
-version = "1.4.9"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/f7/0e652d800358c8c521f791ccf8ad166e5f03a320f06ae42c7ff234ba7d80/msgram_core-1.4.9.tar.gz", hash = "sha256:fb4be2572df88828f2299bdd27d47c94cb5a198b3a7e5d31d967a931a6c386a5", size = 49043, upload-time = "2024-08-21T23:10:29.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/da/cddd85b8582a968b05a5b00bc2bccabab0f7de30207cee8931a161aef255/msgram_core-1.5.4.tar.gz", hash = "sha256:c783d719a4e189f53b76882812d78e3abf5d067d0ab7e817b14f858bf0f3057a", size = 51941, upload-time = "2026-08-24T21:18:28.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/56/c3c06f2344f5ea11cb3d9aa442d6921d07e8cdfa512251aa01ce0538fa5e/msgram_core-1.4.9-py3-none-any.whl", hash = "sha256:41ad23149edfbef5fecaf7dd3d59ad2d93394094b9e6949f6690d4e922c716f9", size = 38550, upload-time = "2024-08-21T23:10:28.413Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e1/ec07d56bd279036e03fa823737075964e73dcd060c6cef5f8f73615c5059/msgram_core-1.5.4-py3-none-any.whl", hash = "sha256:d32e49896b33074895dc8298b4b0208a90f0cc321f8d949b87767914e6a6f62b", size = 41649, upload-time = "2026-08-24T21:18:27.528Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
 ]
 
 [[package]]
@@ -1069,6 +1089,116 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/f7/240c110c08693826b4513a52f5717d62ec7c7af72f2920821247c03b17b3/scipy-1.18.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:457fd7a2a8edeb044ab6ffbc0aa03ff6cd18491356e5e0c834d76ce621b916d1", size = 31111061, upload-time = "2026-08-21T23:23:44.522Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:e708533e8b2ae2497d65346538a7dcc92814410b25b81432eac66de0f2af8265", size = 28733332, upload-time = "2026-08-21T23:23:50.015Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f6/a5b82f8abbe14d134691b8b903696f701d25a081353a29dc655c364d9e62/scipy-1.18.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7bbf207c4453ce1ad2e00b17313852b33310b83090c2311bdaf97f93c0380d12", size = 20475078, upload-time = "2026-08-21T23:23:54.138Z" },
+    { url = "https://files.pythonhosted.org/packages/23/22/0858a0bbd6b3e825ceb8cd9baf9eaf3b2f2b1d77727eb6be40500bcdc92f/scipy-1.18.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:78c0665edead396b1abb4897c41a5c1d9bf090c8a637a4c20a61678e0a264e66", size = 23108904, upload-time = "2026-08-21T23:23:57.824Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9a/2e71719f31eaefe0e3a1706c4a1ded94e664bfd95ffca2b219a671faee01/scipy-1.18.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c085faa2cfa879c5141df483f836f4d691045a078224a670fa570fa01612d89", size = 34025113, upload-time = "2026-08-21T23:24:02.209Z" },
+    { url = "https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f55fa87b6c612ecd6b058f167c53231b1d14e412efe361d3d6e38b3631c73218", size = 35344199, upload-time = "2026-08-21T23:24:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/af/c5538be1792f7034c12c7db6ee67cace58253c7b87b122d68253eaf5de89/scipy-1.18.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c35d74ce0e193ff740c2f2be2ac913ddc232fe6c1ff40b26cfecb9c670c63314", size = 35639587, upload-time = "2026-08-21T23:24:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4c/075e4f66471bac101141ac739e9e135549be1bae584571bd03a530c056e1/scipy-1.18.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d2924a03db38dc2e848bca2fe9f077dafb891480b91a00a0963a8cf86dfc31c1", size = 37480330, upload-time = "2026-08-21T23:24:19.608Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e7/979fd14e75008623df31ba70d6bb144700f68feadcea042021c06a05bf82/scipy-1.18.1-cp312-cp312-win_amd64.whl", hash = "sha256:5e4d44984abc0020154ea81b247adeddcc3ac5527b975ff798bd1ba0adc513c2", size = 36658278, upload-time = "2026-08-21T23:24:25.463Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/e1525354ff9d7d5feb6d1b31af6d14072e5c91e9607b421fa1ec889660b3/scipy-1.18.1-cp312-cp312-win_arm64.whl", hash = "sha256:d65d448389b8436493abcf629cc94ad0cf32aecaf06e1acca1de53cc795f2f12", size = 24400588, upload-time = "2026-08-21T23:24:30.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/4540ee0f9c42a9ad7109d0d1a8cc70de54c3572b01c6693a2b1c70e90ceb/scipy-1.18.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:3ab3523da44749156e1f68b464dc56af11ae4cbc5c739a49d05f32b982eca9f3", size = 31089958, upload-time = "2026-08-21T23:24:35.8Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/769f36d14922b8071a43e95d24d18b6bdafad10d7f5cf647867e1ac052bc/scipy-1.18.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6fb6a55cc0ba97b59a1f288fb86dc6fce8bdfc0fffcbfd015e3a954bf2a2d93", size = 28715106, upload-time = "2026-08-21T23:24:40.775Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d7/21d890274f75ea37a8209d5519e72da3da90302e3b9fb8397a0918386a62/scipy-1.18.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ea324d9dd34c38bfb9bec8ca4d1b407db97dbb74029f566b8e322b1b6fe56fe6", size = 20456846, upload-time = "2026-08-21T23:24:45.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/01/798430ecea2e78ec7c02663d5f71c007bb6abeca931080debd40d7fa55ea/scipy-1.18.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:75b00eb8fb802090aa903f4ea1c7f5a584779f967361e68b7e98e531cc2d7174", size = 23087986, upload-time = "2026-08-21T23:24:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5f/4634e9d35c68496e4e34cb6946eafab044458e6cedab42b40b6588e475b6/scipy-1.18.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d416b16cccfd70fbf62400e84d0bb2f4e6af519a45557f1692c749b37f14b315", size = 33998146, upload-time = "2026-08-21T23:24:54.714Z" },
+    { url = "https://files.pythonhosted.org/packages/41/48/6450ed9243315322bbc19ac57b9b70d66a20bf1d38d124c96bc4bf6af9ea/scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fdaf5ea890a6183d0565f51a61799d67081bd5b1cf03c5f4b3fd3732108625c9", size = 35312578, upload-time = "2026-08-21T23:25:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/bf5a4be6a3525676499f6dff307991739ff6fdcad1481b1aeb6745339f58/scipy-1.18.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c825cef2f49e46753726a7181a8e199804a912b29519ada542c6ebc654951899", size = 35612621, upload-time = "2026-08-21T23:25:06.144Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/3c45c33e00a77996c4b1cb707929f833ba7b1d522ee29f882512c330676d/scipy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3b417bf8c2c7c16e8f58ad91db17783ec911ac16e7b50eb6eab6e809b4f5b07", size = 37457323, upload-time = "2026-08-21T23:25:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0e/e0348fbc0dbab65c114cf78957e7dfeb49f8e8b556b4d930cc12ff195e18/scipy-1.18.1-cp313-cp313-win_amd64.whl", hash = "sha256:559ed65f60c1af5a03f3912605a1b5114f522c7c32fb23c3376ae8f03219fe28", size = 36622841, upload-time = "2026-08-21T23:25:18.722Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/6a77f5f267c555108f0a864b6db714363dab567a8266422a79a385f9232b/scipy-1.18.1-cp313-cp313-win_arm64.whl", hash = "sha256:cd479fc04dd9401e3b4f49e76518768ef99c4f517a98c284eb091fd725719adf", size = 24399315, upload-time = "2026-08-21T23:25:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/d8eb4e280ddb56a4ab2c6f02ee49b56b23f6e977cf0802fd6d68dbef14f5/scipy-1.18.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:83de5453a7799afc9048b4616bd085cef126e36412f0ea2f6370c36a2a3a51e7", size = 31090936, upload-time = "2026-08-21T23:25:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/59ea385dc3a62ff498ddf3cfff7c2b41b0f9f9d3c4122b3f1dcb6d6327fe/scipy-1.18.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:9554bcc6d715ee87a633a3cc8e7703c6628b100dd29cb8a2efc4c0533c7ff729", size = 28725221, upload-time = "2026-08-21T23:25:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/6b0c288c50942d78193696c9f15f9a0874f5178aa0ddf40f83d9924b3e8d/scipy-1.18.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:011413b7426b75012840e35649e00fe0a2c3bae89fed433876e3a99251572efc", size = 20466839, upload-time = "2026-08-21T23:25:37.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e0/54fd3793c729e3b936782f181b59cbb1205bf250ab605a16cb1ba61cdd5e/scipy-1.18.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:88f0e784020649f88ea48c9f5ddfa403bf9205820667c0914740b392035afb82", size = 23089121, upload-time = "2026-08-21T23:25:42.019Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/56/030af62bea3cf878e0028515dff78c123b01633606a879b63f42d2db99cc/scipy-1.18.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d3ab0e8c69a17dd3559eab8cbb88f258e285c94d572c2719033f90f83290c89", size = 34053851, upload-time = "2026-08-21T23:25:47.998Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/89/2a844506d49651e9aa1af6ef95b6bd8031cb1d5a4375edec6155037e04cf/scipy-1.18.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac0333bdf38309aa3dcbe7e3fa7ea29e7a2c37c6ea306a757b700ded8e4596ad", size = 35329183, upload-time = "2026-08-21T23:25:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/c7370c3640e92ac9613cbf26cb3f729f9b12ddf1727b55b94b53b24d6f48/scipy-1.18.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:911de823097db8b63f034299d12662db93344e6ffa0b881cbb57748974b70168", size = 35672551, upload-time = "2026-08-21T23:25:59.387Z" },
+    { url = "https://files.pythonhosted.org/packages/24/16/ec8536f351421f8bf60a1120930638f83790f4710b8230446aca3d6159d4/scipy-1.18.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:95298364e251be3e60249facbeeca03631d3bb7584f85879516ec55ac717b81f", size = 37469416, upload-time = "2026-08-21T23:26:05.432Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/d73da0d28f16c45bb9b0a5691b91610b0275c5ef0eb5e43c87cf2dc1bf31/scipy-1.18.1-cp314-cp314-win_amd64.whl", hash = "sha256:78a0d7c918e74a232394117160e7e3db503377572a45bcef8826e4ab8a35feba", size = 37362755, upload-time = "2026-08-21T23:26:11.366Z" },
+    { url = "https://files.pythonhosted.org/packages/89/25/e996e4dc74e10e227b1e14db5eaf6608bb6dd33884a64851c38f18dd4249/scipy-1.18.1-cp314-cp314-win_arm64.whl", hash = "sha256:cbf38d043c1aa4ab306e1ada6ab6eddacc3322a20b7af1b30bc93254b366fe09", size = 25036090, upload-time = "2026-08-21T23:26:15.887Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/c00213f92309d753b48903e6a451b87eb52ff5b7a16e789d1568bbf221c4/scipy-1.18.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0fcb3c93519f27bb4f0c4b0f7802cdcaca7fcf93267b75edda2e9f4e8a55cbd7", size = 31485550, upload-time = "2026-08-21T23:26:20.776Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b2/e3067c487982d4eeab2938928529410370c06fea84a4d3f4925e7d96647d/scipy-1.18.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ddef79fb382df40104a19bb7151b3b23e57c1778fcf857c71ceecd9bd264513f", size = 29174642, upload-time = "2026-08-21T23:26:25.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ab/374c9fe2d1ec014e576c781a4b5d8e1ba340e8f6b4638c16f711d2b194f0/scipy-1.18.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:0e82073ecc7acc6436fac4b31674109c7e1d3e596789767eda01258a8c9e8123", size = 20916357, upload-time = "2026-08-21T23:26:30.112Z" },
+    { url = "https://files.pythonhosted.org/packages/90/38/223915c88a17317cafbf8ca2a42b11c265a9fb1e804aa665544132b5fe8a/scipy-1.18.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:8bcf3c1ba5d6456e2effd30fcbd3459b044d683fcdac79a2e6830f0bdf7de487", size = 23482611, upload-time = "2026-08-21T23:26:34.846Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d1/db0948da8ca57a80b36520ef0a768b967d99f3af65f4b6f1bf6362ad4dd4/scipy-1.18.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cfbf154f2ba187f2ed6cce2639efff7d105f1140573642c0161615b6d91d6a87", size = 34143202, upload-time = "2026-08-21T23:26:40.4Z" },
+    { url = "https://files.pythonhosted.org/packages/87/53/39d046cc7574ed6acacb6bd5723e220107ece80bff12faaf3efc4ddeede4/scipy-1.18.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d33a7836f7ddc1993427966a0823468ec41bcbdb1a9f9942d1d7e57f803ba3", size = 35380876, upload-time = "2026-08-21T23:26:46.1Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/32e0e799d875a85ca57d9bde6c78148afcc0e38276df683d95854eadc8c3/scipy-1.18.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4b8bc363b6d65ee2152bec57568e3c52639bb34c46057b09857a307ed5e21d", size = 35770885, upload-time = "2026-08-21T23:26:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/f97a666d362fee68b18f41c9c30ed502ca5c98b549749bfcb52a8b74d1eb/scipy-1.18.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11c423f1049c5755ad4409af52a9ada1cff96fe9b50795d4af3619f292901239", size = 37525424, upload-time = "2026-08-21T23:26:56.751Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d5/a9e765a84654ebba8479a1fd1b059ced1af72b168a3b2a3a46540ea38d20/scipy-1.18.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c24acac1e18912761c4700239bbc1fd32f615af690f1584d49b35859be51324d", size = 37416961, upload-time = "2026-08-21T23:27:01.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/16/e79e0d1c63ef698879d85439d37e9fb434e3b804e506a6991038d086ebd9/scipy-1.18.1-cp314-cp314t-win_arm64.whl", hash = "sha256:9f2897bf7737392ad0d5213ea7b6add72a4edf5679b3153106aeb88b6507b3b9", size = 25331848, upload-time = "2026-08-21T23:27:05.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4f/1bd37c883b67163e2ca1f60977a399500e6879c15defecac62831c8d078d/scipy-1.18.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:eb0dfcf4e28a99c12c999744a2ff67c9b06200e20401c7c88186e33552a46331", size = 31091484, upload-time = "2026-08-21T23:27:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c5/ba929d7feb9b2332f96827c12e0e924b61973b59b4dea383b603372c65ce/scipy-1.18.1-cp315-cp315-macosx_12_0_arm64.whl", hash = "sha256:30f464bee641fa8e282577c7dce027308403213c6ca8270bba73285c91024bc5", size = 28725057, upload-time = "2026-08-21T23:27:15.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/19/68f1c50f609d955d230e66d25d02bd3e1e167ec540232135354fb9a4b9e3/scipy-1.18.1-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:1bca3b943fc2567ea49cd02c99abde49da4d5178ec46f624bd8255cda8755beb", size = 20466734, upload-time = "2026-08-21T23:27:20.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/6d/319fa29b73d1802fa80b32a6eaf3f5be456ef81526da2716a9493bcb5501/scipy-1.18.1-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:c9d18a33309122074ea483dd92dd444189166b8b2ec429fe9ed5ac73c7a0aa23", size = 23089664, upload-time = "2026-08-21T23:27:24.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/db/30992f9b51a63de671daf3888ffd18378b6cb9ec9f2c972264238ffa7fd6/scipy-1.18.1-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82f201b4c878551d48558337aab270d3c6cca5507b8737c8d8a608d234cccde0", size = 34054035, upload-time = "2026-08-21T23:27:29.409Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d4/bf3e735dc0b9d5a8ff45079d2540e17d3aff7a2f0048dd8f552ffd031d2b/scipy-1.18.1-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ac49ea97594532dd44b7136094d35f5440fa06e6d9c6384a74c01764df388c5", size = 35333883, upload-time = "2026-08-21T23:27:34.293Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/12d78ce9f871fe945fca588d32644e6e63f553c2a35c564d73f3b22a3313/scipy-1.18.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:ceb30a00ce7c92d459819443d29ca486d882b83fb6738bdcbb2a1cce94ac5daa", size = 35673124, upload-time = "2026-08-21T23:27:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/70/cd/886219313a1012a48e6ae0ec4f302c837151beb92e1ff0d709ef8fdfc488/scipy-1.18.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f29633129f9fa7e88a3f0fca835de2d030bfc9643f7799e1a0c46cee24d38fc7", size = 37470753, upload-time = "2026-08-21T23:27:44.435Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6c/a776888ce618bee54fbde26172f0f46ac1da70d27b63861797fe78e1904b/scipy-1.18.1-cp315-cp315-win_amd64.whl", hash = "sha256:92c14f5bdbfb6216315ce33e78080474082de8b3830122ba97809bfbe65f75c0", size = 37361483, upload-time = "2026-08-21T23:27:49.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/09/97b651691322ebee97999b017ffc18a15a0b815103844c97e8da9d469731/scipy-1.18.1-cp315-cp315-win_arm64.whl", hash = "sha256:e402cf31eb68f453dbb2d36fc6d722b33f24a55d68b2ae1d92fa6305ca71c298", size = 25035883, upload-time = "2026-08-21T23:27:53.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/0f/9ec20467bbabd0d44e2a77d0fd3d124f884b4d67df92af82c91d2d6a486f/scipy-1.18.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:2a0b02f9fc46f8520330c23d45e6560db7e3a0d927232139427637f98943e11d", size = 31474926, upload-time = "2026-08-21T23:27:57.993Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/58/dcb79161e56efbedc50079fcd2f5fe427a0ebb53022eb476aa73c015ad8f/scipy-1.18.1-cp315-cp315t-macosx_12_0_arm64.whl", hash = "sha256:1d73131e358976663dd969e1fb4ed1404b815cd977eaaedc3b3a133ba2d81c35", size = 29164940, upload-time = "2026-08-21T23:28:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d3/1eeea80c817fcb8ef7bd4a05a58824977a0e57a375cfc3d7ea7c911c01ad/scipy-1.18.1-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:bff0b729edd992766136b34e39cc76bc2fad905aa58897ee72a9cd000a6d8443", size = 20906742, upload-time = "2026-08-21T23:28:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/54/46/e59350428b6099301a20128108c995e2eb175a43f383af9a346e38824f9b/scipy-1.18.1-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:10ac20c69d880f77f375db44c22e3e6a644f9fefa291d4cd2fb9790a89fc99fd", size = 23472183, upload-time = "2026-08-21T23:28:12.109Z" },
+    { url = "https://files.pythonhosted.org/packages/89/31/cc91623fa98f0621766a0f0aaaadb2c66de74a7ea7e3837164f6e4354260/scipy-1.18.1-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33a834464fdabc0f26a45508df31b3cc5d028e04dbf6c5ed398541418e0a12fe", size = 34130796, upload-time = "2026-08-21T23:28:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/8572ef536957ddb8aa81bb4090d9e25f257e3b4e05d97deb54319deb8a3a/scipy-1.18.1-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49023963c193dacee096301452f223ee24d86ec5807f8df93c0f7221d119e305", size = 35374253, upload-time = "2026-08-21T23:28:23.732Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c6/59fdeffb4f1435299f93d9dc8140b43ad2916e6cfc944be6c3041fcec86d/scipy-1.18.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:d84a09d0dad90ba6525d8ac1c2334b33e64bf3ccfe9e841f02feb867a22681e4", size = 35758543, upload-time = "2026-08-21T23:28:29.431Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d9/135be205d9de8783193aff9cc3bf483a03a38e4b29432c954e8cb66ac14e/scipy-1.18.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:179ce34a8d0fe273d8883ba59e17e052247d08973dfcb743ca52bb1cce2d60b0", size = 37521946, upload-time = "2026-08-21T23:28:35.245Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a2/5b7d5270621ab7cfa3f7766067bf95dc360b5efb6394694e8143b4156e2b/scipy-1.18.1-cp315-cp315t-win_amd64.whl", hash = "sha256:5632e3ae3d09197c446310cd5187de63e28448ce22f0f67b2b93d97503c0c230", size = 37408295, upload-time = "2026-08-21T23:28:40.724Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ad/741c19fcb66755ff953daf9243af8480e4bf3d7fbe57583c178c7d2b6b51/scipy-1.18.1-cp315-cp315t-win_arm64.whl", hash = "sha256:eda632a7981f69730d6281f451db9c1c370993a2c0d7ddb43e2a809a2862b83a", size = 25319710, upload-time = "2026-08-21T23:28:45.713Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "77.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1093,6 +1223,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/16/10f170ec641ed852611b6c9441b23d10b5702ab5288371feab3d36de2574/sqlparse-0.4.4.tar.gz", hash = "sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c", size = 72383, upload-time = "2023-04-18T08:30:41.994Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/5a/66d7c9305baa9f11857f247d4ba761402cea75db6058ff850ed7128957b7/sqlparse-0.4.4-py3-none-any.whl", hash = "sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3", size = 41183, upload-time = "2023-04-18T08:30:36.96Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Sobe o pin de `msgram-core` de 1.4.9 para 1.5.4 e trata o que essa versão exige do Service.

## O bloqueio

O bump sozinho quebrava a suíte:

| pin | resultado |
|---|---|
| `1.4.9` | 283 testes passando |
| `1.5.4` sem este PR | 37 passando, 246 erros |

Os 246 erros eram `MissingSupportedMetricException` em `create_suported_measures()`, durante o `setUpTestData`, o que derrubava as classes de teste inteiras.

Causa: o `SUPPORTED_MEASURES` que o Service importa vem do próprio core e passou de 8 para 11 medidas. As três novas (`response_time`, `cpu_utilization`, `memory_utilization`) dependem de quatro métricas que o Service não cadastrava: `endpoint_calls`, `mean_response_time`, `cpu_usage` e `memory_usage`.

## O que este PR faz

**Cadastra as métricas de runtime.** Catálogo novo `RUNTIME_AVAILABLE_METRICS`, registrado por `create_runtime_supported_metrics()`. É isto que destrava a carga inicial e devolve os 283 testes.

**Mantém as runtime measures fora do cálculo.** O core valida essas medidas com `CompareRunTimeMeasureSchema`, que exige payload comparando duas releases com dados de APM. O Service não coleta APM nem tem noção de comparar releases, então elas são excluídas em `build_calculated_measures`, com log nomeando o que foi descartado.

A lista não é escrita à mão: `RUNTIME_MEASURE_KEYS` sai do cruzamento entre `SUPPORTED_MEASURES` e `RUNTIME_AVAILABLE_METRICS`, então se o core adicionar outra medida do tipo o Service acompanha sozinho. Um teste crava as três chaves atuais como tripwire, para um rename de métrica no core não transformar o filtro em no-op silencioso.

**Tira as runtime measures do fake data**, que passaria a inventar série histórica para medidas que nunca são calculadas.

## TDD

- `test(metrics): add failing test for #56 (RED)`: testa a invariante estrutural, toda métrica exigida por medida do core está cadastrada. Falha nomeando as quatro faltantes.
- `fix(metrics): ... (GREEN)`: o fix.
- `refactor(metrics): ...`: ajustes de revisão (log do descarte, fake data, documentação do tripwire).

## Validação

- `make test`: 289 testes passando (283 anteriores mais 6 novos), saída `289 passed in 123.88s`. Rodado com `-rsx`, sem nenhum skip ou xfail no relatório.
- Teste de mutação: removi o `.exclude(key__in=RUNTIME_MEASURE_KEYS)` e `test_runtime_measures_are_not_sent_to_the_core` quebrou, então a proteção não é decorativa.
- `make lint` (flake8) limpo.

## O que fica de fora, de propósito

**Coletar as métricas de APM.** Elas não vêm do SonarQube nem da API do GitHub. Enquanto não houver coletor, as três medidas ficam cadastradas e não calculadas. É o próximo passo da issue #56.

**A API passou a listar três medidas incalculáveis.** `SupportedMeasureModelViewSet` devolve `SupportedMeasure.objects.all()`, que agora inclui as runtime measures, e o mesmo vale para as quatro métricas novas em `SupportedMetric`. Isso é fato, verificado no código.

A consequência prática é hipótese, não observação: se alguma tela montar a pré-configuração a partir desse endpoint sem filtrar, dá para selecionar uma medida que o POST recusaria em `validate_subcharacteristics_measures_relation`, com mensagem que não explica o motivo real. Não conferi como o front consome esse endpoint hoje.

Não filtrei nem marquei no serializer porque seria mudança de contrato de API, e isso merece decisão da equipe em vez de carona num bump. Fica registrado aqui e na issue.

**Peso da imagem.** O core 1.5.4 arrasta `scikit-learn` e `scipy` como dependências transitivas novas.

Closes #56
